### PR TITLE
GHA: Remove undefined env. url. value

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,6 @@ jobs:
     needs: setup_and_build
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifact


### PR DESCRIPTION
There is no step with an id of "deployment".  Github actions will silently resolve this to an empty-string.  Remove this attribute since this may be very confusing to future maintainers.