### PR TITLE
GHA: Fix reference to reusable workflow file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   setup_and_build:
-    uses: ./.github/workflows/setup_and_build.yml
+    uses: containers/podman.io/.github/workflows/setup_and_build.yml@main
   deploy:
     needs: setup_and_build
     environment:


### PR DESCRIPTION
Despite the documentation stating that the `uses` attribute may contain a relative path to a file in the repo, this results in the error:

```
Error: .github#L1
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```

Attempt to fix this by using the
`{owner}/{repo}/.github/workflows/{filename}@{ref}` format instead.