### PR TITLE
Updating Podman Desktop to release 1.0.0

### DIFF
--- a/static/data/global.ts
+++ b/static/data/global.ts
@@ -1,4 +1,4 @@
 export const LATEST_VERSION = '4.5.0';
-export const LATEST_DESKTOP_VERSION = '0.15.0';
+export const LATEST_DESKTOP_VERSION = '1.0.0';
 export const MEETING_URL = 'https://meet.google.com/ieq-pxhy-jbh';
 export const RELEASE_NOTES = '';


### PR DESCRIPTION
Podman Desktop 1.0.0 was released this morning, updating so the PD downloads point to the new release.