### PR TITLE
Getting started header

### DIFF
--- a/src/components/content/BasicResourcesBox/data.ts
+++ b/src/components/content/BasicResourcesBox/data.ts
@@ -1,0 +1,22 @@
+const resources = {
+    title: 'Basic Resources',
+    buttons: [
+      {
+        text: 'Installation Instructions',
+        path: 'docs/installation',
+        icon: 'fa6-solid:book',
+      },
+      {
+        text: 'Documentation',
+        path: 'https://docs.podman.io/en/latest/',
+        icon: 'fa6-solid:book',
+      },
+      {
+        text: 'Podman Troubleshooting Guide',
+        path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
+        icon: 'fa6-solid:book',
+      },
+    ],
+  };
+
+  export { resources };

--- a/src/components/content/BasicResourcesBox/index.tsx
+++ b/src/components/content/BasicResourcesBox/index.tsx
@@ -15,7 +15,7 @@ const BasicResourcesBox = () => {
               <li key={index}>
                 <a
                   href={button.path}
-                  className="mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+                  className="no-underline mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
                   <span>{button.text}</span>
                   <Icon icon={button.icon} className="order-first hidden lg:block" />
                 </a>

--- a/src/components/content/BasicResourcesBox/index.tsx
+++ b/src/components/content/BasicResourcesBox/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Icon } from '@iconify/react';
+import { resources } from './data';
+
+const BasicResourcesBox = () => {
+  return (
+    <section className="mt-4 lg:my-0">
+      <header className="container mb-6 text-center xl:mb-8 xl:text-start">
+        <h3 className="font-medium text-blue-700 dark:text-blue-500">{resources.title}</h3>
+      </header>
+      <div>
+        <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:mt-8 lg:gap-4 xl:flex-col">
+          {resources.buttons.map((button, index) => {
+            return (
+              <li key={index}>
+                <a
+                  href={button.path}
+                  className="mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+                  <span>{button.text}</span>
+                  <Icon icon={button.icon} className="order-first hidden lg:block" />
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default BasicResourcesBox;

--- a/src/components/content/BasicResourcesBox/index.tsx
+++ b/src/components/content/BasicResourcesBox/index.tsx
@@ -4,19 +4,19 @@ import { resources } from './data';
 
 const BasicResourcesBox = () => {
   return (
-    <section className="mt-4 lg:my-0">
+    <div className="mt-4 lg:my-0">
       <header className="container mb-6 text-center xl:mb-8 xl:text-start">
         <h3 className="font-medium text-blue-700 dark:text-blue-500">{resources.title}</h3>
       </header>
       <div>
-        <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:mt-8 lg:gap-4 xl:flex-col">
+        <ul className="mb-10 mt-4 flex flex-col gap-6 lg:mb-16 lg:mt-8 lg:gap-4 xl:flex-col">
           {resources.buttons.map((button, index) => {
             return (
               <li key={index}>
                 <a
                   href={button.path}
-                  className="no-underline mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
-                  <span>{button.text}</span>
+                  className="no-underline hover:no-underline leading-none mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+                  <span className="text-left">{button.text}</span>
                   <Icon icon={button.icon} className="order-first hidden lg:block" />
                 </a>
               </li>
@@ -24,7 +24,7 @@ const BasicResourcesBox = () => {
           })}
         </ul>
       </div>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/layout/PageHeader/index.tsx
+++ b/src/components/layout/PageHeader/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
+import { Icon } from '@iconify/react';
 import WaveBorder from '@site/src/components/shapes/WaveBorder';
 import Markdown from '@site/src/components/utilities/Markdown';
 import BasicResourcesBox from '@site/src/components/content/BasicResourcesBox';
@@ -13,11 +14,16 @@ type PageHeaderProps = LayoutProps &
     darkColor?: string;
     lightColor?: string;
     basicResources?: boolean;
+    instructions?: { [key:string]: any };
   };
 
 type PageHeaderSupplementalInfoProps = PageHeaderProps & {
-    image?: Image;
-    basicResources?: boolean;
+  image?: Image;
+  basicResources?: boolean;
+}
+
+type InstructionsProps = PageHeaderProps & {
+  instructions?: { [key:string]: any };
 }
 
 const TextBox = ({ grid, display, layout, title, description }: PageHeaderProps): JSX.Element => {
@@ -28,10 +34,11 @@ const TextBox = ({ grid, display, layout, title, description }: PageHeaderProps)
     </div>
   );
 };
+
 const Image = ({
   grid,
   display,
-  layout,
+  layout,// if array then {[key:string]: any}[];
   image = { path: 'images/raw/podman-2-196w-172h.png', alt: 'Podman Logo' },
 }: ImageSectionProps) => {
   return (
@@ -52,15 +59,43 @@ function PageHeaderSupplementalInfo({ image, basicResources }: PageHeaderSupplem
   );
 }
 
-function PageHeader({ title, description, image, lightColor = 'white', darkColor = 'gray-900', basicResources }: PageHeaderProps) {
+function Instructions({ instructions }: InstructionsProps) {
+  if (instructions) {
+    return (
+      <div>
+        <h3 className="text-gray-700 mb-4">{instructions.title}</h3>
+        <p>{instructions.subtitle}</p>
+         <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:gap-4 xl:flex-col">
+              <li>
+                <a
+                  href={instructions.button.path}
+                  className="no-underline hover:no-underline flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+                  <span>{instructions.button.text}</span>
+                  <Icon icon={instructions.button.icon} className="order-first hidden lg:block" />
+                </a>
+              </li>
+        </ul>
+      </div>
+    )
+  }
+  return null;
+}
+
+function PageHeader({ title, description, image, lightColor = 'white', darkColor = 'gray-900', basicResources, instructions }: PageHeaderProps) {
   return (
-    <header className={`h-5/6  xl:h-100 bg-${lightColor} dark:bg-${darkColor}`}>
-      <div className="-mb-2 bg-gradient-to-r  from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900 lg:pt-8">
+    <header className={`bg-${lightColor} dark:bg-${darkColor}`}>
+      <div className="bg-gradient-to-r  from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900 lg:pt-8">
         <WaveBorder />
       </div>
-      <div className="container grid justify-items-center gap-3 md:grid-cols-2">
-        <TextBox title={title} description={description} layout="mt-12 lg:mt-0" />
-        <PageHeaderSupplementalInfo basicResources={basicResources} />
+      <div className="container flex flex-col md:flex-row justify-around">
+        <div>
+          <TextBox title={title} description={description} layout="mt-12 lg:mt-0 mb-8" />
+          <Instructions instructions={instructions} />
+        </div>
+        <div className="w-[50%] ml-24">
+          <PageHeaderSupplementalInfo basicResources={basicResources} />
+        </div>
+
       </div>
     </header>
   );

--- a/src/components/layout/PageHeader/index.tsx
+++ b/src/components/layout/PageHeader/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import WaveBorder from '@site/src/components/shapes/WaveBorder';
 import Markdown from '@site/src/components/utilities/Markdown';
+import BasicResourcesBox from '@site/src/components/content/BasicResourcesBox';
 type ImageSectionProps = LayoutProps & {
-  image: Image;
+  image?: Image;
 };
 
 type PageHeaderProps = LayoutProps &
@@ -11,7 +12,14 @@ type PageHeaderProps = LayoutProps &
     colors?: Colors;
     darkColor?: string;
     lightColor?: string;
+    basicResources?: boolean;
   };
+
+type PageHeaderSupplementalInfoProps = PageHeaderProps & {
+    image?: Image;
+    basicResources?: boolean;
+}
+
 const TextBox = ({ grid, display, layout, title, description }: PageHeaderProps): JSX.Element => {
   return (
     <div className={`${grid} ${display} ${layout}`}>
@@ -33,7 +41,18 @@ const Image = ({
   );
 };
 
-function PageHeader({ title, description, image, lightColor = 'white', darkColor = 'gray-900' }: PageHeaderProps) {
+function PageHeaderSupplementalInfo({ image, basicResources }: PageHeaderSupplementalInfoProps) {
+  if (basicResources) {
+    return (
+      <BasicResourcesBox />
+    );
+  } 
+  return (
+    <Image image={image} layout="mb-8 lg:mb-0" />
+  );
+}
+
+function PageHeader({ title, description, image, lightColor = 'white', darkColor = 'gray-900', basicResources }: PageHeaderProps) {
   return (
     <header className={`h-5/6  xl:h-100 bg-${lightColor} dark:bg-${darkColor}`}>
       <div className="-mb-2 bg-gradient-to-r  from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900 lg:pt-8">
@@ -41,7 +60,7 @@ function PageHeader({ title, description, image, lightColor = 'white', darkColor
       </div>
       <div className="container grid justify-items-center gap-3 md:grid-cols-2">
         <TextBox title={title} description={description} layout="mt-12 lg:mt-0" />
-        <Image image={image} layout="mb-8 lg:mb-0" />
+        <PageHeaderSupplementalInfo basicResources={basicResources} />
       </div>
     </header>
   );

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -11,6 +11,7 @@ import FeaturesCarousel from '@site/src/components/content/FeaturesCarousel';
 /* PAGE DATA */
 import { header, knowPodman, learnMore } from '@site/static/data/features';
 import PlayOnScroll from '@site/src/components/utilities/PlayOnScroll';
+import BasicResourcesBox from '@site/src/components/content/BasicResourcesBox';
 
 /* PAGE COMPONENTS */
 function GetToKnowPodmanSection() {
@@ -169,6 +170,7 @@ const PodmanCLISection = () => {
   );
 };
 
+/* TODO Should be componentized at some point */
 const LearnArticles = () => {
   const [blogData, setBlogData] = useState([]);
 
@@ -219,39 +221,13 @@ const LearnArticles = () => {
   );
 };
 
-const LearnResources = () => {
-  return (
-    <section className="mt-4 lg:my-0">
-      <header className="container mb-6 text-center xl:mb-8 xl:text-start">
-        <h3 className="font-medium text-blue-700 dark:text-blue-500">{learnMore.resources.title}</h3>
-      </header>
-      <div>
-        <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:mt-8 lg:gap-4 xl:flex-col">
-          {learnMore.resources.cards.map((card, index) => {
-            return (
-              <li key={index}>
-                <a
-                  href={card.path}
-                  className="mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
-                  <span>{card.text}</span>
-                  <Icon icon={card.icon} className="order-first hidden lg:block" />
-                </a>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    </section>
-  );
-};
-
 const LearnMoreSection = () => {
   return (
     <section>
       <SectionHeader title={learnMore.title} textGradient={true} textGradientStops="from-purple-500 to-purple-900" />
       <div className="container mt-8 flex flex-wrap justify-center gap-24">
         <LearnArticles />
-        <LearnResources />
+        <BasicResourcesBox />
       </div>
     </section>
   );

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -19,7 +19,7 @@ const GetHelpSection = () => {
           <h3 className="text-white dark:text-white ">{getHelp.subtitle}</h3>
         </header>
         <div className="mx-auto">
-          <div className="container grid max-w-6xl grid-cols-1 gap-y-4 lg:grid-cols-2 lg:gap-y-0">
+          <div className="container grid  grid-cols-1 gap-y-4 lg:grid-cols-2 lg:gap-y-0">
             <p className="max-w-sm text-white dark:text-gray-100">
               For more details, you can review the <a href="https://docs.podman.io/en/latest/Commands.html">manpages</a>
               :
@@ -31,7 +31,7 @@ const GetHelpSection = () => {
                 {'\n'}
               </CodeBlock>
           </div>
-          <div className="container grid max-w-6xl grid-cols-1 gap-y-4 lg:grid-cols-2 lg:gap-y-0">
+          <div className="container grid grid-cols-1 gap-y-4 lg:grid-cols-2 lg:gap-y-0">
             <p className="max-w-sm text-white">
               To get some help and find out how Podman is working, you can use the help.
             </p>

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -70,7 +70,7 @@ const SearchPullListSection = () => {
 function GetStarted() {
   return (
     <Layout>
-      <PageHeader title={header.title} description={header.subtitle} />
+      <PageHeader title={header.title} description={header.subtitle} basicResources={true} />
       <GetHelpSection />
       <SearchPullListSection />
     </Layout>

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -12,7 +12,7 @@ import { header, getHelp } from '@site/static/data/get-started';
 /* PAGE COMPONENTS */
 const GetHelpSection = () => {
   return (
-    <section className=" mt-12 bg-gradient-to-br from-purple-500/75 to-purple-900 dark:from-purple-700 dark:via-purple-900 dark:to-gray-900 lg:mt-32">
+    <section className="bg-gradient-to-br from-purple-900 to-purple-500/75 dark:from-purple-700 dark:via-purple-900 dark:to-gray-900">
       <SectionHeader title={getHelp.title} textColor="dark:text-blue-500 text-blue-300" />
       <div className="container my-8">
         <header className="text-center lg:my-8">
@@ -45,11 +45,11 @@ const GetHelpSection = () => {
       </div>
       <div className="container mb-8 mt-4 text-center lg:mb-20 lg:mt-6">
         <p className="text-white">
-          'Please also reference the{' '}
+          Please also reference the{' '}
           <a href="https://github.com/containers/podman/blob/main/troubleshooting.md" className="text-blue-300">
             <strong>Podman Troubleshooting Guide</strong>
           </a>{' '}
-          to find known issues and tips on how to solve common configuration mistakes.'
+          to find known issues and tips on how to solve common configuration mistakes.
         </p>
       </div>
       <WaveBorder />
@@ -70,7 +70,7 @@ const SearchPullListSection = () => {
 function GetStarted() {
   return (
     <Layout>
-      <PageHeader title={header.title} description={header.subtitle} basicResources={true} />
+      <PageHeader title={header.title} description={header.subtitle} basicResources={true} instructions={header.instructions} />
       <GetHelpSection />
       <SearchPullListSection />
     </Layout>

--- a/static/data/get-started.ts
+++ b/static/data/get-started.ts
@@ -1,35 +1,15 @@
 const header = {
   title: 'Get Started with Podman',
   subtitle:
-    'Podman is a utility provided as part of the libpod library. It can be used to create and maintain containers. The following tutorial will teach you how to set up Podman and perform some basic commands. First, check that you have already [installed Podman](https://podman-desktop.io/downloads)',
+    'Podman is a utility provided as part of the libpod library. It can be used to create and maintain containers. The following tutorial will teach you how to set up Podman and perform some basic commands.',
   instructions: {
     title: 'First Things First: Installing Podman',
     subtitle: 'For installing or building Podman, please see the installation instructions:',
     button: {
       text: 'Installation Instructions',
-      path: '#',
+      path: 'docs/installation',
       icon: 'fa6-solid:book',
     },
-  },
-  resources: {
-    title: 'Basic Resources',
-    buttons: [
-      {
-        text: 'Installation Instructions',
-        path: '#',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Documentation',
-        path: '#',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Podman Troubleshooting Guide',
-        path: '#',
-        icon: 'fa6-solid:book',
-      },
-    ],
   },
 };
 


### PR DESCRIPTION
Will help but won't fully fix #49 so just mentioning here
Will address #87 

This adds in the missing instruction block on the Getting Started header, cleans up the text there, adds the "Basic resources" links to docs present in the mockup (on the live site it's just the cute seal), and converts the layout from grid to flex which fixes some rendering issues I observed (eg the header content running *under* the first content block about
manpages :-/ )

## BEFORE
![Screenshot from 2023-05-18 22-07-01](https://github.com/containers/podman.io/assets/799683/8a26966f-f344-4fb1-a74c-649802aab985)
![Screenshot from 2023-05-18 22-06-54](https://github.com/containers/podman.io/assets/799683/ee5fdad1-498e-46c2-b20a-81a671c8a370)

## AFTER
![Screenshot from 2023-05-18 22-01-29](https://github.com/containers/podman.io/assets/799683/c038239f-1cb0-4aa0-a3cb-81461c02723c)
![Screenshot from 2023-05-18 22-00-58](https://github.com/containers/podman.io/assets/799683/29c49de2-99ba-4957-aa28-2f0daab0dbad)

Note I'm not super chuffed about the appearance of the resource links in narrow / responsive mode, will cover in a separate issue/pr.