### PR TITLE
installation.md: PREFIX is also neccesary for build

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -455,7 +455,7 @@ First, ensure that the `go version` that is found first on the $PATH is 1.16.x o
 ```bash
 git clone https://github.com/containers/podman/
 cd podman
-make BUILDTAGS="selinux seccomp"
+make BUILDTAGS="selinux seccomp" PREFIX=/usr
 sudo make install PREFIX=/usr
 ```
 


### PR DESCRIPTION
When `make` is run without `PREFIX`, container services generated by quadlet generator contains `ExecStart=/usr/local/bin/podman ...` instead of expected `$PREFIX/bin/podman`

Fixes:
    $ make BUILDTAGS="selinux seccomp"
    $ sudo make install PREFIX=/usr
     ...

    podmansh.service: Failed at step EXEC spawning /usr/local/bin/podman: No such file or directory