### PR TITLE
installation.md: remove `-y` from `apt-get update`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -203,7 +203,7 @@ and newer.
 
 ```bash
 # Ubuntu 20.10 and newer
-sudo apt-get -y update
+sudo apt-get update
 sudo apt-get -y install podman
 ```
 


### PR DESCRIPTION
`apt-get update` does not need a `-y`. It is a no-op. See:
1. https://embeddedinventor.com/sudo-apt-get-update-y-command-explained-for-beginners/
2. https://askubuntu.com/questions/976080/is-y-redundant-in-apt-get-update