### PR TITLE
Use current Windows installer instead of legacy MSI for CLI installation

### DIFF
--- a/src/components/layout/HeroHeader/installOptions.ts
+++ b/src/components/layout/HeroHeader/installOptions.ts
@@ -11,10 +11,10 @@ const operatingSystemData = [
     },
     alt: {
       title: 'Podman CLI for Windows',
-      subtitle: `Windows MSI Installer v-${LATEST_VERSION}`,
+      subtitle: `Podman Windows Installer v-${LATEST_VERSION}`,
       icon: 'material-symbols:terminal-rounded',
       options: [],
-      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-v${LATEST_VERSION}.msi`,
+      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-${LATEST_VERSION}-setup.exe`,
     },
     other: {
       path: 'docs/installation',


### PR DESCRIPTION
The signed WIX burn based setup.exe installer should be used over the legacy one. (After this is approved/merged and the site is updated, I'd like to remove the msi files from github releases since the old installer will likely lead to user confusion and bug reports). 

I have a separate PR (containers/podman#19349) to drop the legacy installer entirely since having two installers could confuse contributors as well. 