### PR TITLE
chore: update Podman Desktop version to v1.3.1

### DIFF
--- a/static/data/global.ts
+++ b/static/data/global.ts
@@ -1,5 +1,5 @@
 export const LATEST_VERSION = '4.6.1';
-export const LATEST_DESKTOP_VERSION = '1.2.1';
-export const LATEST_DESKTOP_DOWNLOAD_URL = 'https://podman-desktop.io/blog/podman-desktop-release-1.2';
+export const LATEST_DESKTOP_VERSION = '1.3.1';
+export const LATEST_DESKTOP_DOWNLOAD_URL = 'https://podman-desktop.io/blog/podman-desktop-release-1.3';
 export const MEETING_URL = 'https://meet.google.com/ieq-pxhy-jbh';
 export const RELEASE_NOTES = '';


### PR DESCRIPTION
Podman Desktop v1.3.1 has been released 🎉
Update website for v1.3.1

Signed-off-by: Denis Golovin <dgolovin@redhat.com>