### PR TITLE
Fix testimonial featured link href

### DIFF
--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -31,7 +31,7 @@ function Testimonial(props: TestimonialProps) {
       </div>
       <div className="mt-2 mb-4 truncate">
         <p className="whitespace-normal text-gray-900 dark:text-gray-300 leading-snug mb-2">{props.description}</p>
-        {props.featuredlink && <a href={props.featuredlink}>{props.featuredlink}</a>}
+        {props.featuredlink && <a target="_blank" href={props.featuredlink}>{props.featuredlink}</a>}
       </div>
       <div className="mt-auto self-start text-gray-300 dark:text-gray-700 italic">
         <a href={props.path} className="text-gray-300 dark:text-gray-700 dark:hover:text-gray-700 no-underline hover:no-underline hover:bg-purple-300">

--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -4,11 +4,12 @@ import { Icon } from '@iconify/react';
 type TestimonialProps = {
   name: string;
   handle: string;
-  image?: Image;
   description: string;
   social: string;
   path: string;
   date: string;
+  avatar: string;
+  featuredlink?: string;
 };
 
 function Testimonial(props: TestimonialProps) {
@@ -30,7 +31,7 @@ function Testimonial(props: TestimonialProps) {
       </div>
       <div className="mt-2 mb-4 truncate">
         <p className="whitespace-normal text-gray-900 dark:text-gray-300 leading-snug mb-2">{props.description}</p>
-        {props.featuredlink && <a href="{props.featuredlink}">{props.featuredlink}</a>}
+        {props.featuredlink && <a href={props.featuredlink}>{props.featuredlink}</a>}
       </div>
       <div className="mt-auto self-start text-gray-300 dark:text-gray-700 italic">
         <a href={props.path} className="text-gray-300 dark:text-gray-700 dark:hover:text-gray-700 no-underline hover:no-underline hover:bg-purple-300">


### PR DESCRIPTION
## Description
Fixes the testimonials present at the bottom of https://podman.io to have working links.

Currently, every featured link points to `https://podman.io/%7Bprops.featuredlink%7D`.

As a side note, I noticed that the Tweet for the first testimonial on the page has since been deleted, so someone may want to find another testimonial to replace that one at some point.

## Steps to Reproduce
1. Navigate to https://podman.io
2. Scroll to the "What people are saying about Podman" section
3. Click on one of the featured links in one of the testimonies, e.g. the GitHub link in `Fang-Pen Lin`'s tweet. 
4. Notice that we navigate to `https://podman.io/%7Bprops.featuredlink%7D` instead of the tweet

Video: 

https://github.com/containers/podman.io/assets/24928223/ea54584e-b637-439b-8084-7edd739bc5cb

