### PR TITLE
Add RSS Feed link in the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,6 +125,10 @@ const config = {
                 label: 'Mailing List',
                 href: 'https://lists.podman.io',
               },
+              {
+                label: 'RSS Feed',
+                href: 'https://blog.podman.io/feed/',
+              },
             ],
           },
           {


### PR DESCRIPTION
A RSS feed is  linked in the footer.

closes #148 

Signed-off-by: Chetan Giradkar <cgiradka@redhat.com>