### PR TITLE
Include containernetworking-plugins in ubuntu deps

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -316,6 +316,7 @@ Debian, Ubuntu, and related distributions:
 ```bash
 sudo apt-get install \
   btrfs-progs \
+  containernetworking-plugins \
   crun \
   git \
   golang-go \


### PR DESCRIPTION
Not including the containernetworking-plugins package on Ubuntu Server 20.04 LTS gives the following error when building and running from source:

```
WARN[0001] Failed to load cached network config: network podman not found in CNI cache, falling back to loading network podman from disk 
WARN[0001] 1 error occurred:
        * plugin type="tuning" failed (delete): failed to find plugin "tuning" in path [/usr/local/libexec/cni /usr/libexec/cni /usr/local/lib/cni /usr/lib/cni /opt/cni/bin]
 
Error: plugin type="bridge" failed (add): failed to find plugin "bridge" in path [/usr/local/libexec/cni /usr/libexec/cni /usr/local/lib/cni /usr/lib/cni /opt/cni/bin]
```

After `sudo apt -y install containernetworking-plugins`, this message goes away and I can sucessfully start a container.