### PR TITLE
Make markdown links in clickable on community page

### DIFF
--- a/src/components/ui/CustomCard/index.tsx
+++ b/src/components/ui/CustomCard/index.tsx
@@ -30,7 +30,9 @@ function CardBody(props) {
   const { text } = props;
   return (
     <div className="mx-2 my-6 overflow-y-auto lg:my-8">
-      <p className="text-gray-700 dark:text-gray-100">{text}</p>
+      <p id="cardBody-parsed" className="text-gray-700 dark:text-gray-100">
+        <Markdown text={text} />
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
Any markdown link of the form
\[text\]\(url\)
will be convertd to:
`<a href={url}>{text}</a>`
using the MarkDown component.

closes #185 

Signed-off-by: Chetan Giradkar <cgiradka@redhat.com>