### PR TITLE
Restore old blogs from podman_old.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,6 +46,7 @@ const config = {
         },
         blog: {
           showReadingTime: true,
+          routeBasePath: 'blogs',
         },
         theme: {
           customCss: require.resolve('./src/css/main.css'),


### PR DESCRIPTION
The format which was used formerly and that used by Docusaurus are incompatible. Hence, corrected yaml fields from the markdown files. Then made provisions to display the blogs.

closes #125