### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -203,6 +203,7 @@ and newer.
 
 ```bash
 # Ubuntu 20.10 and newer
+sudo add-apt-repository universe
 sudo apt-get update
 sudo apt-get -y install podman
 ```


### PR DESCRIPTION
Ubuntu instructions fail without having the universe repository added. 

- Adding command to enable universe repository to Ubuntu podman install instructions.