### PR TITLE
Add link to podman-py docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -216,6 +216,11 @@ For more information on how to setup and run the integration tests in your
 environment, checkout the Integration Tests
 [README.md](https://github.com/containers/podman/blob/main/test/README.md).
 
+## Podman Python Documentation
+
+The documentation for the Podman Python SDK is located
+[here](https://podman-py.readthedocs.io/en/latest/index.html).
+
 ## More information
 
 For more information on Podman and its subcommands, checkout the asciiart demos

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,6 +33,11 @@ const sidebars = {
       label: 'Network',
       href: 'https://github.com/containers/podman/blob/main/docs/tutorials/basic_networking.md',
     },
+    {
+      type: 'link',
+      label: 'Podman Python',
+      href: 'https://podman-py.readthedocs.io/en/latest/index.html',
+    },
   ],
 };
 module.exports = sidebars;


### PR DESCRIPTION
Add link to podman-py docs under documentation.
Add link to the sidebar as well.