### PR TITLE
Recommend installing Podman CLI from pkginstaller on Mac

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,19 +17,38 @@ programmatic access from your language of choice.
 
 ### macOS
 
-On Mac, each Podman machine is backed by a [QEMU](https://www.qemu.org) based
-virtual machine. Once installed, the podman command can be run directly from
+On Mac, each Podman machine is backed by a virtual machine. 
+Once installed, the podman command can be run directly from
 the Unix shell in `Terminal`, where it remotely communicates with the podman
 service running in the Machine VM.
 
-For Mac, Podman is provided through [Homebrew](https://brew.sh/). Once you
+<details open>
+<summary>Download Podman Installer (Reccomended)</summary>
+
+Podman can be downloaded from the [Podman.io](https://podman.io) website.
+
+We also upload the installers and other binaries on our [Github release page](https://github.com/containers/podman/releases).
+
+</details>
+
+Though not reccomended, Podman can also be obtained through Homebrew,
+the package manager.
+<details>
+<summary>Install via Brew</summary>
+
+Since Brew is a community-maintained package manager, we cannot guarantee stability
+of Brew installs of Podman. Thus, installing via Brew is not reccomended.
+
+However, if you do wish to use Brew, you must first install [Homebrew](https://brew.sh/). Once you
 have set up brew, you can use the `brew install` command to install Podman:
 
 ```bash
 brew install podman
 ```
 
-Next, create and start your first Podman machine:
+</details>
+
+After installing, you need to create and start your first Podman machine:
 
 ```bash
 podman machine init

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -18,7 +18,10 @@ const detectOperatingSystem = () => {
   if (userAgent.find(item => item.includes('windows'))) {
     return 'windows';
   } else if (userAgent.find(item => item.includes('macintosh'))) {
-    return 'macintosh';
+    if (userAgent.find(item => item.includes('intel'))){
+      return 'mac_amd';
+    }
+    return 'mac_arm';
   }
   return 'linux';
 };

--- a/src/components/layout/HeroHeader/installOptions.ts
+++ b/src/components/layout/HeroHeader/installOptions.ts
@@ -22,7 +22,7 @@ const operatingSystemData = [
     },
   },
   {
-    id: 'macintosh',
+    id: 'mac_amd',
     preferred: {
       title: 'Podman Desktop for macOS',
       subtitle: `Universal *.dmg v-${LATEST_DESKTOP_VERSION}`,
@@ -32,9 +32,29 @@ const operatingSystemData = [
     },
     alt: {
       title: 'Podman CLI for macOS',
-      subtitle: `Install using Brew`,
+      subtitle: `CLI only installer for Intel Macs`,
       icon: 'material-symbols:terminal-rounded',
-      path: `docs/installation#macos`,
+      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-amd64.pkg`,
+    },
+    other: {
+      path: 'docs/installation',
+      text: 'Other Install Options',
+    },
+  },
+  {
+    id: 'mac_arm',
+    preferred: {
+      title: 'Podman Desktop for macOS',
+      subtitle: `Universal *.dmg v-${LATEST_DESKTOP_VERSION}`,
+      icon: 'fa-brands:apple',
+      options: [],
+      path: `https://github.com/containers/podman-desktop/releases/download/v${LATEST_DESKTOP_VERSION}/podman-desktop-${LATEST_DESKTOP_VERSION}-universal.dmg`,
+    },
+    alt: {
+      title: 'Podman CLI for macOS',
+      subtitle: `CLI only installer for Apple silicon`,
+      icon: 'material-symbols:terminal-rounded',
+      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-arm64.pkg`,
     },
     other: {
       path: 'docs/installation',


### PR DESCRIPTION
Since Brew is a community-maintained package manager, we cannot guarantee stability of Brew installs of Podman. Reccomend installing Podman from our pkginstaller instead.

This commit also changes the secondary install option from brew to a link to download the pkginstaller.


<img width="660" alt="Screenshot 2024-01-10 at 11 54 23 AM" src="https://github.com/containers/podman.io/assets/32910034/ad1ec9ba-960d-4606-9470-68aeb6560daa">

