### PR TITLE
Added HTML sanitization to the blogs card

### DIFF
--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -24,7 +24,14 @@ const Title = (title: string) => {
 };
 
 function ArticleCard(props: ArticleCardProps) {
-  const abbrSubtitle = props.subtitle.trim().split(' ').slice(0, 32).join(' ').concat('...');
+  // Sanitizes HTML and converts it to plain text
+  const sanitizeHtml = (html: string) => {
+    if (!html) return html;
+    const div = document.createElement("div");
+    div.innerHTML = html;
+    return div.textContent || div.innerText || "";
+  };
+  const abbrSubtitle = sanitizeHtml(props.subtitle).trim().split(' ').slice(0, 32).join(' ').concat('...');
   if (props.altLayout) {
     return (
       <article className="my-4 max-w-2xl shadow-lg">
@@ -36,7 +43,7 @@ function ArticleCard(props: ArticleCardProps) {
                   href={props.path}
                   target="_blank"
                   className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
-                  {props.title}
+                  {sanitizeHtml(props.title)}
                 </a>
               </h3>
               <PublishDate date={props.date} styles="col-start-1 order-1 row-start-1 z-10" />
@@ -66,7 +73,7 @@ function ArticleCard(props: ArticleCardProps) {
               href={props.path}
               target="_blank"
               className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
-              {props.title}
+              {sanitizeHtml(props.title)}
             </a>
           </h3>
           {parse(abbrSubtitle)}


### PR DESCRIPTION
### Why
The WordPress API returns HTML instead of plain text it will cause blog post card to break since react needs them as plain text:

<img width="470" alt="Screenshot 2024-01-16 at 10 15 19 PM" src="https://github.com/containers/podman.io/assets/8397274/f6bdf1fe-692d-4c07-8400-ac0d9bcdab59">


### The fix
Added HTML to plain text encoding to prevent this from happening. This will also remove all the unnecessary `<p>` tags added by the WP API.

<img width="457" alt="Screenshot 2024-01-16 at 10 15 29 PM" src="https://github.com/containers/podman.io/assets/8397274/86734317-aac3-4dfa-82ee-07b5dd79df87">
