### PR TITLE
Fixed Graphic being cut off and distorted

### DIFF
--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -123,7 +123,7 @@ function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, pla
               })}
             </ul>
           </div>
-          <div className="hidden justify-end md:flex lg:mb-12 lg:w-[510px] 2xl:w-full">
+          <div className="z-10 hidden justify-end md:flex lg:mb-12 lg:w-[510px] 2xl:w-full">
             <img src={image.path} alt={image.alt} className="object-cover" />
           </div>
         </div>


### PR DESCRIPTION
Added z-index to fix cut-off graphic.

Before:
![image](https://github.com/containers/podman.io/assets/11181348/bd8c3297-056c-46de-9612-d130796b3ad4)
![image](https://github.com/containers/podman.io/assets/11181348/63a0077f-ee76-40c8-9920-15f1a79c8088)


After:
![image](https://github.com/containers/podman.io/assets/11181348/2735ae64-edea-46e1-8c38-216671330c6d)
![image](https://github.com/containers/podman.io/assets/11181348/f0078aa8-ca3f-4387-8204-6c5ad8c1f7e3)
