### PR TITLE
Recommend Universal Mac installer

### DIFF
--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -18,10 +18,7 @@ const detectOperatingSystem = () => {
   if (userAgent.find(item => item.includes('windows'))) {
     return 'windows';
   } else if (userAgent.find(item => item.includes('macintosh'))) {
-    if (userAgent.find(item => item.includes('intel'))){
-      return 'mac_amd';
-    }
-    return 'mac_arm';
+    return 'mac';
   }
   return 'linux';
 };

--- a/src/components/layout/HeroHeader/installOptions.ts
+++ b/src/components/layout/HeroHeader/installOptions.ts
@@ -22,7 +22,7 @@ const operatingSystemData = [
     },
   },
   {
-    id: 'mac_amd',
+    id: 'mac',
     preferred: {
       title: 'Podman Desktop for macOS',
       subtitle: `Universal *.dmg v-${LATEST_DESKTOP_VERSION}`,
@@ -32,29 +32,9 @@ const operatingSystemData = [
     },
     alt: {
       title: 'Podman CLI for macOS',
-      subtitle: `CLI only installer for Intel Macs`,
+      subtitle: `CLI only universal installer`,
       icon: 'material-symbols:terminal-rounded',
-      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-amd64.pkg`,
-    },
-    other: {
-      path: 'docs/installation',
-      text: 'Other Install Options',
-    },
-  },
-  {
-    id: 'mac_arm',
-    preferred: {
-      title: 'Podman Desktop for macOS',
-      subtitle: `Universal *.dmg v-${LATEST_DESKTOP_VERSION}`,
-      icon: 'fa-brands:apple',
-      options: [],
-      path: `https://github.com/containers/podman-desktop/releases/download/v${LATEST_DESKTOP_VERSION}/podman-desktop-${LATEST_DESKTOP_VERSION}-universal.dmg`,
-    },
-    alt: {
-      title: 'Podman CLI for macOS',
-      subtitle: `CLI only installer for Apple silicon`,
-      icon: 'material-symbols:terminal-rounded',
-      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-arm64.pkg`,
+      path: `https://github.com/containers/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-universal.pkg`,
     },
     other: {
       path: 'docs/installation',

--- a/static/data/global.ts
+++ b/static/data/global.ts
@@ -1,4 +1,4 @@
-export const LATEST_VERSION = '4.9.3';
+export const LATEST_VERSION = '5.0.0';
 export const LATEST_DESKTOP_VERSION = '1.8.0';
 export const LATEST_DESKTOP_DOWNLOAD_URL = 'https://podman-desktop.io/blog/podman-desktop-release-1.8';
 export const MEETING_URL = 'https://meet.google.com/xrq-uemd-bzy';


### PR DESCRIPTION
We now ship a universal installer for Mac that works on both archs. Default to downloading/recommending it over arch specific installers.

Bump Podman to v5.0.0