### PR TITLE
Change cabal to the first Tues of Odd Months

### DIFF
--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -73,7 +73,7 @@ const communityMeetings = {
       title: 'Podman Community Cabal',
       subtitle:
         'The focus of the cabal meeting is the planning and discussion of possible future changes to Podman or the [related Containers projects](https://github.com/containers) and discussing any outstanding issues that might need solving.',
-      date: '**3rd Tuesday** every month',
+      date: '**1st Tuesday** of odd numbered months',
       timeZone: '11 AM US ET /5 PM CET',
       buttons: [
         { text: 'Join Meeting', path: MEETING_URL },


### PR DESCRIPTION
Due to the light attendance of the Podman Community Cabal meetings as of late.  We have decided to move them to the first Tuesday of odd numbered months, so that way the first Tuesday of each month will now have either a Community or a Cabal meeting.