### PR TITLE
Add missing date to Cabal notes

### DIFF
--- a/static/data/meetings/notes/2024-07-02/index.md
+++ b/static/data/meetings/notes/2024-07-02/index.md
@@ -1,4 +1,5 @@
 # Podman Community Cabal Agenda
+## Jul 2, 2024 11:00 a.m. Eastern (UTC-4)
 ### Attendees: Ralph Bean, Sumantro Mukherjee, Chris Evich, Dan Walsh, Ashley Cui, Neil Smith, Paul Holzinger, Lokesh Mandvekar, Ashley Cui, and others not noted.
 
 ### Meeting Notes

--- a/static/data/meetings/notes/2024-09-03/index.md
+++ b/static/data/meetings/notes/2024-09-03/index.md
@@ -1,4 +1,5 @@
 # Podman Community Cabal Agenda
+## Sep 3, 2024 11:00 a.m. Eastern (UTC-4)
 
 ### Attendees
 Anders, Daniel Walsh, Ed Santiago Munoz, Gerry Seidman, Giuseppe Scrivano, Jan Rodak, Jhon Honce, Kevin Clevenger, Lokesh Mandvekar, Mario Loriedo, Matt Heon, Miloslav Trmac, Mohan Boddu, Nalin Dahyabhai, Paul Holzinger, Rick Wagner, Tom Sweeney


### PR DESCRIPTION
Touch up the dates on the last two cabal meetings notes and see if that fixes the look of the Community page which is whacked at the moment.

Regardless, adding the date is a good thing