### PR TITLE
docs/installation.md: Add dependencies for building on Debian

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -366,7 +366,7 @@ Debian, Ubuntu, and related distributions:
 ```bash
 sudo apt-get install \
   btrfs-progs \
-  crun \
+  gcc \
   git \
   golang-go \
   go-md2man \
@@ -385,7 +385,9 @@ sudo apt-get install \
   libsystemd-dev \
   make \
   netavark \
+  passt \
   pkg-config \
+  runc \
   uidmap
 ```
 


### PR DESCRIPTION
# TL;DR:

* Added `gcc`: for `make` for conmon and podman
* Added `passt`: for `could not find pasta` error (Fixes #285)
* Switch `crun` -> `runc`: for error running container unknown version specified error in Debian

# Details

## Problem: `cc`/`gcc` not found for conmon and podman
<details>

### conmon

```bash
$ make
cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -o src/conmon.o -c src/conmon.c
/bin/sh: 1: cc: not found
make: *** [Makefile:68: src/conmon.o] Error 127
```

### podman

```bash
$ make BUILDTAGS="seccomp"
Podman is being compiled without the systemd build tag. 	Install libsystemd on Ubuntu or systemd-devel on rpm based 	distro for journald support.
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
	 \
	-ldflags '-X github.com/containers/podman/v5/libpod/define.gitCommit=4cbdfde5d862dcdbe450c0f1d76ad75360f67a3c -X github.com/containers/podman/v5/libpod/define.buildInfo=1737063691 -X github.com/containers/podman/v5/libpod/config._installPrefix=/usr/local -X github.com/containers/podman/v5/libpod/config._etcDir=/etc -X github.com/containers/podman/v5/pkg/systemd/quadlet._binDir=/usr/local/bin -X github.com/containers/common/pkg/config.additionalHelperBinariesDir= ' \
	-tags "seccomp" \
	-o bin/podman ./cmd/podman
# runtime/cgo
cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
make: *** [Makefile:377: bin/podman] Error 1
```
</details>

## Solution: install gcc (doc updated)
<details>

### conmon compiles

```bash
    podman-bento-debian12: ========= Setup conmon =========
    podman-bento-debian12: mkdir -p bin
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/conmon.o -c src/conmon.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/cmsg.o -c src/cmsg.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/ctr_logging.o -c src/ctr_logging.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/utils.o -c src/utils.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/cli.o -c src/cli.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/globals.o -c src/globals.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/cgroup.o -c src/cgroup.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/conn_sock.o -c src/conn_sock.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/oom.o -c src/oom.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/ctrl.o -c src/ctrl.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/ctr_stdio.o -c src/ctr_stdio.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/parent_pipe_fd.o -c src/parent_pipe_fd.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/ctr_exit.o -c src/ctr_exit.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/runtime_args.o -c src/runtime_args.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/close_fds.o -c src/close_fds.c
    podman-bento-debian12: cc -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o src/seccomp_notify.o -c src/seccomp_notify.c
    podman-bento-debian12: cc  -std=c99 -Os -Wall -Wextra -Werror -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -DVERSION=\"2.1.12\" -DGIT_COMMIT=\""119db20187a4356abd4d31d76ad53063a7a2e85e"\"  -D USE_JOURNALD=1  -D USE_SECCOMP=1  -o bin/conmon src/conmon.o src/cmsg.o src/ctr_logging.o src/utils.o src/cli.o src/globals.o src/cgroup.o src/conn_sock.o src/oom.o src/ctrl.o src/ctr_stdio.o src/parent_pipe_fd.o src/ctr_exit.o src/runtime_args.o src/close_fds.o src/seccomp_notify.o -lglib-2.0  -lsystemd  -lseccomp  -ldl
    podman-bento-debian12: install  -d -m 755 /usr/local/libexec/podman
    podman-bento-debian12: install  -m 755 bin/conmon /usr/local/libexec/podman/conmon
    podman-bento-debian12: 
```

### podman compiles

(screenshot huge omitted)
</details>

## Problem: `crun unknown version specified` error in Debian

<details>

When building an image with `podman`, I ran into an error on a basic `apt` update/upgrade/install step with `error running container: from /usr/bin/crun creating container....unknown version specified`. In googling the error, I ran into the very similar issue [containers/crun#1485] indicating it might be resolved in a newer version of crun. I was already on the latest available for Debian 12, without building from source, so I decided to try `runc` instead, since this is explicitly listed as supported in the `podman` docs. The docs explicitly call out `crun` taking precedence over `runc` if both are installed, so I understand if this isn't a desired change since it might appear to go against defaults, and I'm willing to revert it if there is strong opinions on it.

```bash
$ podman build
...
<snipped>
...
STEP 6/17: RUN apt-get update     && apt-get upgrade     && apt-get -y install --no-install-recommends wget ca-certificates unzip libsecret-1-0 jq     && apt-get clean     && rm -rf /var/lib/apt/lists/*
error running container: from /usr/bin/crun creating container for [/bin/sh -c apt-get update     && apt-get upgrade     && apt-get -y install --no-install-recommends wget ca-certificates unzip libsecret-1-0 jq     && apt-get clean     && rm -rf /var/lib/apt/lists/*]: unknown version specified
: exit status 1
Error: building at STEP "RUN apt-get update     && apt-get upgrade     && apt-get -y install --no-install-recommends wget ca-certificates unzip libsecret-1-0 jq     && apt-get clean     && rm -rf /var/lib/apt/lists/*": while running runtime: exit status 1

vagrant@podman:/vagrant$ apt list crun
Listing... Done
crun/stable,now 1.8.1-1+deb12u1 amd64 [installed]
```
</details>

## Solution: switch to `runc`  (doc updated)

<details>

The documentation explicitly points out that either should be fine... so runc?

```bash
podman build
...
<snipped>
...
STEP 6/17: RUN apt-get update     && apt-get upgrade     && apt-get -y install --no-install-recommends wget ca-certificates unzip libsecret-1-0 jq     && apt-get clean     && rm -rf /var/lib/apt/lists/*
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]
Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [13.5 kB]
Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [241 kB]
Fetched 9301 kB in 2s (4063 kB/s)
...
<snipped>
...
done.
--> ceddc949aae3
STEP 7/17: ...
```
</details>

## Problem: could not find pasta
<details>

```bash
$ podman run --env ENVVAR localhost/hdub-tech/podmanio test
Error: could not find pasta, the network namespace can't be configured: exec: "pasta": executable file not found in $PATH
```
</details>

## Solution: install passt (doc updated)
<details>

```bash
$ sudo apt-get install -y passt

$ podman run --env ENVVAR localhost/hdub-tech/podmanio test
Test completed successfully
```
</details>