### PR TITLE
Update install instructions for Linux Mint

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -173,8 +173,6 @@ sudo apt-get -y install podman
 
 Follow the steps for Ubuntu (or Debian if you use LMDE).
 
-Replace `$(lsb_release -rs)` with `$(grep DISTRIB_RELEASE= /etc/upstream-release/lsb-release | cut -d "=" -f 2)` for Ubuntu steps.
-
 ### Installing development versions of Podman
 
 #### [Fedora](https://getfedora.org)


### PR DESCRIPTION
The Linux Mint instructions were still referring to steps in the Ubuntu and Debian instructions that do not exist in this version of the docs.
Ubuntu instructions were tested on Linux Mint 22.1 ISO