### PR TITLE
Updating the Slack link to point to CNCF slack #podman channel

### DIFF
--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -43,7 +43,7 @@ const communityChat = {
     },
     {
       text: 'Slack',
-      path: 'https://slack.k8s.io/',
+      path: 'https://cloud-native.slack.com/archives/C08MXJLCFCN',
       icon: 'logos:slack-icon',
     },
   ],


### PR DESCRIPTION
With the move to CNCF, podman community moved to CNCF slack.