### PR TITLE
Updated the command to enable user ns permanently.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -435,7 +435,7 @@ sudo sysctl kernel.unprivileged_userns_clone=1
 To enable the user namespaces permanently:
 
 ```
-echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/userns.conf
+echo 'kernel.unprivileged_userns_clone=1' | sudo tee /etc/sysctl.d/userns.conf > /dev/null
 ```
 
 ### Building missing dependencies


### PR DESCRIPTION
All other commands in the doc have `sudo` wherever required, except this one.

Fixing the same.