### PR TITLE
remove slack links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,6 +126,10 @@ const config = {
             title: 'Community',
             items: [
               {
+                label: 'Matrix',
+                href: 'https://matrix.to/#/#podman:fedoraproject.org',
+              },
+              {
                 label: 'Discord',
                 href: 'https://discord.com/invite/x5GzFF6QH4',
               },

--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -2,7 +2,7 @@ import { MEETING_URL } from './global';
 const header = {
   title: 'Community',
   subtitle:
-    'We want your feedback, issues, patches, and involvement in the development of Podman. **Chat** with us on Slack, IRC, or on our **mailing list**. Submit **issues & pull requests** (see our [CONTRIBUTING guide](https://github.com/containers/podman/blob/main/CONTRIBUTING.md) on how.) Participate in one of our twice-monthly community meetings. You are welcome in our community!',
+    'We want your feedback, issues, patches, and involvement in the development of Podman. **Chat** with us on Matrix, Discord, IRC, or on our **mailing list**. Submit **issues & pull requests** (see our [CONTRIBUTING guide](https://github.com/containers/podman/blob/main/CONTRIBUTING.md) on how.) Participate in one of our twice-monthly community meetings. You are welcome in our community!',
   image: 'images/raw/podman-2-196w-172h.png',
   banner: {
     text: 'To help ensure all feel welcome in the Podman community, we expect all who participate to adhere to our [Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md)',
@@ -40,11 +40,6 @@ const communityChat = {
       text: 'Podman Discord',
       path: 'https://discord.gg/vwpj7K6gW5',
       icon: 'logos:discord-icon',
-    },
-    {
-      text: 'Slack',
-      path: 'https://cloud-native.slack.com/archives/C08MXJLCFCN',
-      icon: 'logos:slack-icon',
     },
   ],
 };


### PR DESCRIPTION
The cncf slack channels will no longer be used.
Also touch up the page to mention Matrix and Discord first.