### PR TITLE
Fix raw markdown being placed on the community page.

### DIFF
--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -87,7 +87,7 @@ const MailingListSection = (): JSX.Element => {
         />
         <section className="container mb-8">
           <h3 className="mb-2 font-medium text-purple-700 dark:text-purple-500">{mailingList.browseInfo.title}</h3>
-          <p className="max-w-prose text-gray-500">{mailingList.browseInfo.subtitle}</p>
+          <Markdown text={mailingList.browseInfo.subtitle} styles="max-w-prose" />
         </section>
         <section className="container mb-8">
           <h3 className="mb-2 font-medium text-purple-700 dark:text-purple-500">{mailingList.subscribeInfo.title}</h3>


### PR DESCRIPTION
I noticed on the mailing list section of https://podman.io/community there is the following text:

```
Simply visit [the Podman mailing list website](https://lists.podman.io/) to browse or search previous postings to the Podman mailing list.
```

This is because the Markdown is not converted to HTML. This patch fixes it, so that the link is turned into an href.