### PR TITLE
Fix markdown formatting in Deployment section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you're doing development on a VM there are a few steps to take to test your c
 ### Deployment
 
 - The site is set to automatically deploy when code is pushed to the main branch
-  - See `.github/workflows/static.yml
+  - See `.github/workflows/static.yml`
 - **Important**: prior to merging to main, run `yarn build` locally
 
 ---


### PR DESCRIPTION
This PR corrects a minor markdown formatting issue in the Deployment section of the Podman.io Website README. A missing closing backtick has been added to the .github/workflows/static.yml filename to ensure proper code formatting. This change improves readability; no functional changes are involved.