### PR TITLE
Fix dead link to yarn installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This website is built using [Docusaurus 2](https://docusaurus.io/).
 
 Follow these steps to test the site with either a local development server, or by statically generating the site.
 
-- [_make sure yarn is installed_](https://classic.yarnpkg.com/lang/docs/install/)
+- [_make sure yarn is installed_](https://classic.yarnpkg.com/lang/en/docs/install/#debian-stable)
 - Install packages
   - `$ yarn`
 - Run a local development server


### PR DESCRIPTION
I noticed this dead link in the README. Based on the diff, it looks like yarn localized their website, which broke the previous link.