### PR TITLE
Remove unnecessary `-t`

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -9,7 +9,7 @@ run the example container as root. Instead of prefixing each command with
 `sudo`, you can also switch to the root user beforehand via `sudo -i`.
 
 ```bash
-sudo podman run -dt -p 8080:80/tcp docker.io/library/httpd
+sudo podman run -d -p 8080:80/tcp docker.io/library/httpd
 sudo podman ps
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,13 +81,12 @@ This sample container will run a very basic httpd server that serves only its
 index page.
 
 ```bash
-podman run -dt -p 8080:80/tcp docker.io/library/httpd
+podman run -d -p 8080:80/tcp docker.io/library/httpd
 ```
 
 **Note**: Because the container is being run in detached mode, represented by
 the `-d` in the `podman run` command, Podman will print the container ID after
-it has executed the command. The `-t` also adds a pseudo-tty to run arbitrary
-commands in an interactive shell.
+it has executed the command.
 
 **Note**: We use port forwarding to be able to access the HTTP server. For
 successful running at least slirp4netns v0.3.0 is needed.


### PR DESCRIPTION
Do not combine `-t` (`--tty`) and `-d` (`--detach`)

Fixes: https://github.com/containers/podman.io/issues/468