### PR TITLE
fix(deps): restore missing eslint-plugin-prettier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/parser": "^5.48.2",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
     "prettier": "2.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5761,6 +5761,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:^4.2.1":
+  version: 4.2.5
+  resolution: "eslint-plugin-prettier@npm:4.2.5"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+  peerDependencies:
+    eslint: ">=7.28.0"
+    prettier: ">=2.0.0"
+  peerDependenciesMeta:
+    eslint-config-prettier:
+      optional: true
+  checksum: 22c29ba685f18516e3b1595e062849ccc108996a759da6067ff5d876519a5f81c8ba92c0c5623a1c62b593d417619ba44ab3b6ec1450ca753c078fd92970b883
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
@@ -6041,6 +6056,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.1.2":
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: d22d371b994fdc8cce9ff510d7b8dc4da70ac327bcba20df607dd5b9cae9f908f4d1028f5fe467650f058d1e7270235ae0b8230809a262b4df587a3b3aa216c3
   languageName: node
   linkType: hard
 
@@ -9640,6 +9662,7 @@ __metadata:
     clsx: ^1.2.1
     eslint: ^8.32.0
     eslint-config-prettier: ^8.6.0
+    eslint-plugin-prettier: ^4.2.1
     html-react-parser: ^3.0.16
     husky: ^8.0.3
     lint-staged: ^13.1.0
@@ -10181,6 +10204,15 @@ __metadata:
   version: 2.0.0
   resolution: "prepend-http@npm:2.0.0"
   checksum: 7694a9525405447662c1ffd352fcb41b6410c705b739b6f4e3a3e21cf5fdede8377890088e8934436b8b17ba55365a615f153960f30877bf0d0392f9e93503ea
+  languageName: node
+  linkType: hard
+
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "prettier-linter-helpers@npm:1.0.1"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 2dc35f5036a35f4c4f5e645887edda1436acb63687a7f12b2383e0a6f3c1f76b8a0a4709fe4d82e19157210feb5984b159bb714d43290022911ab53d606474ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION




## What's broken

`yarn lint` has been crashing on a clean checkout for a while now:

```
Oops! Something went wrong! :(
ESLint: 8.57.1
ESLint couldn't find the plugin "eslint-plugin-prettier".
```

`.eslintrc` extends `"prettier"`, lists `"prettier"` in `plugins`, and has a`"prettier/prettier": ["error"]` rule, all of which need the`eslint-plugin-prettier` package. `package.json` only has `eslint-config-prettier`, which is a different package that does something different (it just turns off ESLint rules that'd conflict with Prettier  it doesn't run Prettier as a rule).


## Fix
#542 


## Testing

Since there's no test suite here, I verified manually:

- `yarn install --immutable` — passes clean
- `yarn build` — succeeds
- `yarn lint` — the original "couldn't find the plugin" crash is gone

<img width="1013" height="423" alt="image" src="https://github.com/user-attachments/assets/4a8746bc-f5b7-4270-b470-5193ea47e7e1" />
