### PR TITLE
improve blog page readability and spacing

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -166,3 +166,34 @@
 [data-theme='dark'] img[src$='#gh-light-mode-only'] {
   display: none;
 }
+
+/* ------------------ */
+/* Blog Styling */
+/* ------------------ */
+
+/* Add visual separation between blog posts */
+main[itemtype*="Blog"] article[itemprop="blogPost"] {
+  margin-bottom: 0 !important;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  padding: 2rem 0;
+}
+
+/* Add a divider above the first blog post */
+main[itemtype*="Blog"] article[itemprop="blogPost"]:first-child {
+  border-top: 1px solid var(--ifm-toc-border-color);
+}
+
+/* Add spacing before the blog pagination */
+main[itemtype*="Blog"] .pagination-nav {
+  margin-top: 2rem;
+}
+
+/* Align blog titles with post metadata */
+main[itemtype*="Blog"] article[itemprop="blogPost"] h2 {
+  padding: 0;
+}


### PR DESCRIPTION
I have improved the styling of the blog listing page by adding visual separation between blog posts using horizontal dividers and consistent spacing. I also added spacing before the blog pagination to improve the overall layout and readability.
The styling changes are scoped only to the blog page, ensuring that other pages of the website remain unaffected.
I have run the website locally using `yarn start` and verified that the blog page renders correctly. I also confirmed that the changes work as expected without introducing visual changes to other sections of the website.

### Before
<img width="1912" height="5646" alt="002_ Blog _Podman" src="https://github.com/user-attachments/assets/aac3f0ba-280a-4b75-96b6-918d2eec9b5e" />


### After
<img width="1912" height="5529" alt="001 _Blog -_Podman" src="https://github.com/user-attachments/assets/3985fc0f-fa28-49ac-a16e-b3072ddd7101" />