### PR TITLE
Fix : Remove unused resources data containing dead link from features.ts

### DIFF
--- a/static/data/features.ts
+++ b/static/data/features.ts
@@ -88,26 +88,6 @@ const carouselContent = [
 ];
 const learnMore = {
   title: 'Want to learn more?',
-  resources: {
-    title: 'Basic Podman Resources',
-    cards: [
-      {
-        text: 'Installation Instructions',
-        path: '#',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Documentation',
-        path: 'https://docs.podman.io',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Podman Troubleshooting',
-        path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
-        icon: 'fa6-solid:book',
-      },
-    ],
-  },
   blogPosts: {
     title: 'Recent Podman Blog Posts',
   },


### PR DESCRIPTION
`learnMore.resources` in `static/data/features.ts` contains an "Installation Instructions" card with `path: '#'`  a dead link 

Additionally, this entire `resources` block is never consumed. 

The Features page renders resources via the `BasicResourcesBox` 
component, which has its own data file in (`src/components/content/BasicResourcesBox/data.ts`) with the 
correct paths

I have tested the features tab after these changes and it was successfully navigate to the links in section "want to learn more?"
