### PR TITLE
fix: align items to the start position of the testimonial section 

### DIFF
--- a/src/components/content/TestimonialSection/index.tsx
+++ b/src/components/content/TestimonialSection/index.tsx
@@ -29,7 +29,7 @@ function TestimonialSection() {
         </button>
         <div
           id="slider"
-          className="mx-auto flex h-full w-full justify-center overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar">
+          className="mx-auto flex h-full w-full justify-start overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar">
           {testimonials.map((testimonial, index) => {
             return <Testimonial key={index} {...testimonial} />;
           })}


### PR DESCRIPTION
In the testimonial section of the website, the item in the first position of the flex container got cut off. I modified the justify position to align with the first item.

This PR addresses #573 which displays the modifications made to the user interface.