### PR TITLE
Fix/issue 579 hero links 

### DIFF
--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -106,29 +106,29 @@ function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, pla
               {() => <DropdownButton text="Download" option={InstallOption(returnOperatingSystemData())} />}
             </BrowserOnly>
           </div>
-          <p className="flex flex-nowrap items-center gap-4 whitespace-nowrap text-white dark:text-gray-100">
+          <p className="flex flex-wrap items-center gap-x-4 gap-y-1 text-white dark:text-gray-100">
             <Link
               text={`Podman v${podmanrelease.text}`}
               path={podmanrelease.path}
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-blue-100"
-              className="rounded px-1 -mx-1 font-semibold hover:bg-white/20"
+              hoverColor="hover:text-purple-300"
+              className="font-semibold"
             />
             <span>-</span>
             <Link
               text={`Podman Desktop v${desktoprelease.text}`}
               path={desktoprelease.path}
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-blue-100"
-              className="rounded px-1 -mx-1 font-semibold hover:bg-white/20"
+              hoverColor="hover:text-purple-300"
+              className="font-semibold"
             />
             <span>-</span>
             <Link
               text="Apache License 2.0"
               path="https://www.apache.org/licenses/LICENSE-2.0"
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-blue-100"
-              className="rounded px-1 -mx-1 font-semibold hover:bg-white/20"
+              hoverColor="hover:text-purple-300"
+              className="font-semibold"
             />
           </p>
         </div>

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -106,19 +106,33 @@ function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, pla
               {() => <DropdownButton text="Download" option={InstallOption(returnOperatingSystemData())} />}
             </BrowserOnly>
           </div>
-          <p className="flex gap-4 text-white dark:text-gray-100">
+          <p className="flex flex-wrap gap-4 text-white dark:text-gray-100">
             <span>
-              Latest stable Podman <Link {...podmanrelease} textColor="text-white dark:text-gray-100" />
+              Latest stable Podman{' '}
+              <Link
+                {...podmanrelease}
+                textColor="text-white dark:text-gray-100"
+                hoverColor="hover:text-blue-100"
+                className="rounded px-1 -mx-1 font-semibold hover:bg-white/10"
+              />
             </span>
             <span>-</span>
             <span>
-              Latest stable Podman Desktop <Link {...desktoprelease} textColor="text-white dark:text-gray-100" />
+              Latest stable Podman Desktop{' '}
+              <Link
+                {...desktoprelease}
+                textColor="text-white dark:text-gray-100"
+                hoverColor="hover:text-blue-100"
+                className="rounded px-1 -mx-1 font-semibold hover:bg-white/10"
+              />
             </span>
             <span>-</span>
             <Link
               text="Apache License 2.0"
               path="https://www.apache.org/licenses/LICENSE-2.0"
               textColor="text-white dark:text-gray-100"
+              hoverColor="hover:text-blue-100"
+              className="rounded px-1 -mx-1 font-semibold hover:bg-white/10"
             />
           </p>
         </div>

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -106,33 +106,29 @@ function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, pla
               {() => <DropdownButton text="Download" option={InstallOption(returnOperatingSystemData())} />}
             </BrowserOnly>
           </div>
-          <p className="flex flex-wrap gap-4 text-white dark:text-gray-100">
-            <span>
-              Latest stable Podman{' '}
-              <Link
-                {...podmanrelease}
-                textColor="text-white dark:text-gray-100"
-                hoverColor="hover:text-blue-100"
-                className="rounded px-1 -mx-1 font-semibold hover:bg-white/10"
-              />
-            </span>
+          <p className="flex flex-nowrap items-center gap-4 whitespace-nowrap text-white dark:text-gray-100">
+            <Link
+              text={`Podman v${podmanrelease.text}`}
+              path={podmanrelease.path}
+              textColor="text-white dark:text-gray-100"
+              hoverColor="hover:text-blue-100"
+              className="rounded px-1 -mx-1 font-semibold hover:bg-white/20"
+            />
             <span>-</span>
-            <span>
-              Latest stable Podman Desktop{' '}
-              <Link
-                {...desktoprelease}
-                textColor="text-white dark:text-gray-100"
-                hoverColor="hover:text-blue-100"
-                className="rounded px-1 -mx-1 font-semibold hover:bg-white/10"
-              />
-            </span>
+            <Link
+              text={`Podman Desktop v${desktoprelease.text}`}
+              path={desktoprelease.path}
+              textColor="text-white dark:text-gray-100"
+              hoverColor="hover:text-blue-100"
+              className="rounded px-1 -mx-1 font-semibold hover:bg-white/20"
+            />
             <span>-</span>
             <Link
               text="Apache License 2.0"
               path="https://www.apache.org/licenses/LICENSE-2.0"
               textColor="text-white dark:text-gray-100"
               hoverColor="hover:text-blue-100"
-              className="rounded px-1 -mx-1 font-semibold hover:bg-white/10"
+              className="rounded px-1 -mx-1 font-semibold hover:bg-white/20"
             />
           </p>
         </div>

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -106,29 +106,30 @@ function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, pla
               {() => <DropdownButton text="Download" option={InstallOption(returnOperatingSystemData())} />}
             </BrowserOnly>
           </div>
-          <p className="flex flex-wrap items-center gap-x-4 gap-y-1 text-white dark:text-gray-100">
+          <p className="flex flex-wrap items-center gap-2 text-white dark:text-gray-100">
             <Link
               text={`Podman v${podmanrelease.text}`}
               path={podmanrelease.path}
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-purple-300"
-              className="font-semibold"
+              hoverColor="hover:text-purple-300 hover:border-purple-300"
+              underline="no-underline"
+              className="rounded-full border border-white/30 px-3 py-1 text-sm font-semibold"
             />
-            <span>-</span>
             <Link
               text={`Podman Desktop v${desktoprelease.text}`}
               path={desktoprelease.path}
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-purple-300"
-              className="font-semibold"
+              hoverColor="hover:text-purple-300 hover:border-purple-300"
+              underline="no-underline"
+              className="rounded-full border border-white/30 px-3 py-1 text-sm font-semibold"
             />
-            <span>-</span>
             <Link
               text="Apache License 2.0"
               path="https://www.apache.org/licenses/LICENSE-2.0"
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-purple-300"
-              className="font-semibold"
+              hoverColor="hover:text-purple-300 hover:border-purple-300"
+              underline="no-underline"
+              className="rounded-full border border-white/30 px-3 py-1 text-sm font-semibold"
             />
           </p>
         </div>

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -111,25 +111,25 @@ function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, pla
               text={`Podman v${podmanrelease.text}`}
               path={podmanrelease.path}
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-purple-300 hover:border-purple-300"
-              underline="no-underline"
-              className="rounded-full border border-white/30 px-3 py-1 text-sm font-semibold"
+              hoverColor="hover:text-white hover:dark:text-gray-100 hover:border-purple-300 hover:bg-purple-900/60"
+              underline="no-underline hover:no-underline"
+              className="rounded-full border border-white/30 px-4 py-1.5 text-base font-semibold"
             />
             <Link
               text={`Podman Desktop v${desktoprelease.text}`}
               path={desktoprelease.path}
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-purple-300 hover:border-purple-300"
-              underline="no-underline"
-              className="rounded-full border border-white/30 px-3 py-1 text-sm font-semibold"
+              hoverColor="hover:text-white hover:dark:text-gray-100 hover:border-purple-300 hover:bg-purple-900/60"
+              underline="no-underline hover:no-underline"
+              className="rounded-full border border-white/30 px-4 py-1.5 text-base font-semibold"
             />
             <Link
               text="Apache License 2.0"
               path="https://www.apache.org/licenses/LICENSE-2.0"
               textColor="text-white dark:text-gray-100"
-              hoverColor="hover:text-purple-300 hover:border-purple-300"
-              underline="no-underline"
-              className="rounded-full border border-white/30 px-3 py-1 text-sm font-semibold"
+              hoverColor="hover:text-white hover:dark:text-gray-100 hover:border-purple-300 hover:bg-purple-900/60"
+              underline="no-underline hover:no-underline"
+              className="rounded-full border border-white/30 px-4 py-1.5 text-base font-semibold"
             />
           </p>
         </div>

--- a/src/components/utilities/Link/index.tsx
+++ b/src/components/utilities/Link/index.tsx
@@ -6,6 +6,7 @@ export type LinkProps = Link & {
   hoverColor?: string;
   underline?: string;
   target?: string;
+  className?: string;
 };
 function Link({
   text,
@@ -14,13 +15,14 @@ function Link({
   textColor = 'text-blue-700 dark:text-blue-500',
   hoverColor = 'hover:text-purple-700 hover:dark:text-purple-700',
   underline = 'underline underline-offset-4',
-  target = '_self'
+  target = '_self',
+  className = ''
 }: LinkProps): JSX.Element {
   return (
     <a
       href={path}
       target={target}
-      className={`${fontSize} ${textColor} ${hoverColor} ${underline} cursor-pointer transition duration-150 ease-in`}>
+      className={`${fontSize} ${textColor} ${hoverColor} ${underline} ${className} cursor-pointer transition duration-150 ease-in`}>
       {text}
     </a>
   );


### PR DESCRIPTION
#579 

This PR improves the version links displayed in the Hero section by making them more noticeable and updating their labels to be more descriptive

**Changes**
1. Improved the visual styling of version links to make them easier to identify as clickable.
2. Renamed generic link labels to more descriptive names.
3. Kept version numbers alongside the product names for better clarity.

**Before**
<img width="1071" height="632" alt="Screenshot 2026-07-29 at 3 05 26 PM" src="https://github.com/user-attachments/assets/491e8ba4-12cc-46a3-81f4-d3634a9cfbd2" />


**After**
<img width="829" height="508" alt="Screenshot 2026-07-29 at 4 29 45 PM" src="https://github.com/user-attachments/assets/53548963-2ee2-4768-a0e3-625d0fe23f35" />
