### PR TITLE
Fix redundant Mailing List subscribe text on Community page

### DIFF
--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -90,9 +90,9 @@ const mailingList = {
   subscribeInfo: {
     title: 'Subscribe or post to the mailing list',
     subtitle:
-      'Simply visit [the Podman mailing list website](https://lists.podman.io/) to browse or search previous postings to the Podman mailing list.',
+      'You can subscribe to the mailing list to post questions, share feedback, or follow discussions about Podman.',
     description:
-      "Regardless of which method you use, a confirmation email will be sent to you. After you reply back to that confirmation email, you'll then be able to send mail directly to podman@lists.podman.io Send an email to [podman-join@lists.podman.io](mailto:podman-join@lists.podman.io). You can then also go to [the web page](https://lists.podman.io) and manage your subscription.",
+      "Regardless of which method you use, a confirmation email will be sent to you. After you reply, you'll be able to send mail directly to podman@lists.podman.io. You can also manage your subscription at [the mailing list website](https://lists.podman.io/).",
     options: [
       {
         title: 'Option 1',


### PR DESCRIPTION
The "Subscribe or post to the mailing list" subsection on the Community 
page duplicated the same text "Simply visit ...."  and it also need to be refactored 


## Before


<img width="1203" height="573" alt="Screenshot from 2026-07-29 22-48-45" src="https://github.com/user-attachments/assets/0deefb10-c164-4f9f-982e-1f9f51cd1514" />


## After

<img width="1203" height="563" alt="Screenshot from 2026-07-29 22-48-05" src="https://github.com/user-attachments/assets/2b8134ef-1a73-41ca-b049-bb758b9dd39d" />



