### PR TITLE
fix: author is added in _fields for the blog slug

### DIFF
--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -177,7 +177,7 @@ const LearnArticles = () => {
   useEffect(() => {
     const fetchData = async () => {
       const rawData = await fetch(
-        'https://blog.podman.io/wp-json/wp/v2/posts?per_page=4&_fields=id, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt',
+        'https://blog.podman.io/wp-json/wp/v2/posts?per_page=4&_fields=id, author, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt',
       );
       const jsonData = await rawData.json();
       setBlogData(jsonData);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,7 +53,7 @@ const LatestNews = () => {
   useEffect(() => {
     const fetchData = async () => {
       const rawData = await fetch(
-        'https://blog.podman.io/wp-json/wp/v2/posts?per_page=4&_fields=id, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt',
+        'https://blog.podman.io/wp-json/wp/v2/posts?per_page=4&_fields=id, author, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt',
       );
       const jsonData = await rawData.json();
       setBlogData(jsonData);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Concisely describe the change
Fixes #612 


In `src/pages/index.tsx` (line 56) and `src/pages/features.tsx` (line 180), add author to the` _fields` query parameter:
**_fields=id, author, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt**
Tested against the API without **author** in `_fields`, the response returns author_link: "**https://blog.podman.io/author/**". With it included, the correct slug is returned e.g. "**https://blog.podman.io/author/mloriedo/**".

#### Before screenshot / screen recording

https://github.com/user-attachments/assets/3bbe8452-3019-4e23-b4a0-63b2a87f4f91


#### After screenshot / screen recording


https://github.com/user-attachments/assets/50a058a2-9df9-4f91-acc3-1f9743038b22


<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/9db31596-2c92-4705-9773-1853bfa6bed8" />


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
