### PR TITLE
Use placeholder instead of value in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -4,12 +4,12 @@ title: "[Bug]: "
 body:
   - type: textarea
     attributes:
-      label: Consisely describe the issue
-      value: Consisely describe the issue, and what page it is on. Consisely describe the feature. Do not use a LLM.
+      label: Concisely describe the issue
+      placeholder: Concisely describe the issue, and what page it is on. Do not use an LLM.
   - type: textarea
     attributes:
       label: Upload screenshots or screen recordings
-      value:  Add screenshots or screen recordings to help explain your problem.
+      placeholder: Add screenshots or screen recordings to help explain your problem.
     validations:
       required: false
   - type: checkboxes
@@ -17,5 +17,5 @@ body:
     attributes:
       label: LLM Policy
       options:
-        - label: This issue is human-written, and folow up comments will also be human-written
+        - label: This issue is human-written, and follow up comments will also be human-written
           required: true

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -4,12 +4,12 @@ title: "[Feature]: "
 body:
   - type: textarea
     attributes:
-      label: Consisely describe the feature.
-      value: Consisely describe the feature. Do not use a LLM.
+      label: Concisely describe the feature
+      placeholder: Concisely describe the feature. Do not use an LLM.
   - type: textarea
     attributes:
       label: Upload screenshots
-      value:  Add screenshots or proposed mockups (optional).
+      placeholder: Add screenshots or proposed mockups (optional).
     validations:
       required: false
   - type: checkboxes
@@ -17,5 +17,5 @@ body:
     attributes:
       label: LLM Policy
       options:
-        - label: This issue is human-written, and folow up comments will also be human-written
+        - label: This issue is human-written, and follow up comments will also be human-written
           required: true


### PR DESCRIPTION
#### Concisely describe the change

In `.github/ISSUE_TEMPLATE/bug.yaml` and `.github/ISSUE_TEMPLATE/feature.yaml`, default guidance text was set on `attributes.value` for `textarea` form fields. In GitHub Issue Forms, `value` pre-populates editable text inside input boxes, forcing users to manually highlight and delete default text whenever creating a bug report or feature proposal (Fixes #609).

Replaced `attributes.value` with `attributes.placeholder` across all `textarea` fields in `bug.yaml` and `feature.yaml`. `placeholder` provides a hint text inside empty text fields that automatically disappears upon typing without polluting submitted markdown or requiring manual deletion. Fixed minor typos (`Consisely` -> `Concisely`, `folow` -> `follow`, `a LLM` -> `an LLM` and removed copy-paste fragment in `bug.yaml`).

#### Before screenshot / screen recording
N/A (YAML issue form configuration change)

#### After screenshot / screen recording
N/A (YAML issue form configuration change)

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)

