### PR TITLE
fix: align title banners and card layout in latest podman news section

### DIFF
--- a/src/components/content/BlogArticlesList/index.tsx
+++ b/src/components/content/BlogArticlesList/index.tsx
@@ -34,35 +34,38 @@ const BlogArticlesList: React.FC<BlogArticlesListProps> = ({
   }
 
   const containerClasses =
-    containerLayout === 'vertical' ? 'flex flex-col gap-4' : 'flex flex-wrap justify-center gap-4';
+    containerLayout === 'vertical'
+      ? 'flex flex-col gap-4'
+      : 'flex flex-wrap justify-center gap-6 items-stretch';
 
   return (
     <section className={sectionClassName}>
       <SectionHeader title={title} textColor={titleColor} />
       <div className={containerClasses}>
         {data.slice(0, actualDisplayCount).map((card, index) => (
-          <ArticleCard
-            key={card.id}
-            title={card.title.rendered}
-            author_link={card.author_info.author_link}
-            display_name={card.author_info.display_name}
-            subtitle={card.excerpt.rendered}
-            date={card.wbDate}
-            imgSrc={card.jetpack_featured_media_url}
-            path={card.link}
-            altLayout={altLayout}
-            index={index}
-          />
+          <div key={card.id} className="w-80 flex flex-col">
+            <ArticleCard
+              title={card.title.rendered}
+              author_link={card.author_info.author_link}
+              display_name={card.author_info.display_name}
+              subtitle={card.excerpt.rendered}
+              date={card.wbDate}
+              imgSrc={card.jetpack_featured_media_url}
+              path={card.link}
+              altLayout={altLayout}
+              index={index}
+            />
+          </div>
         ))}
       </div>
       {showFooter && footerText && (
-        <p className="ml-2l text-center 2xl:text-start">
+        <p className="ml-2l text-center 2xl:text-start mt-6">
           {footerText}{' '}
           <a
             href="https://blog.podman.io"
             target="_blank"
             rel="noopener noreferrer"
-            className="underline-offset-4 transition duration-150 ease-linear hover:text-purple-700 dark:hover:text-purple-500">
+            className="underline-offset-4 transition duration-150 ease-linear hover:text-purple-700 dark:hover:text-purple-50">
             on our Blog!
           </a>
         </p>

--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import parse from 'html-react-parser';
+
 type ArticleCardProps = {
   title: string;
-  subtitle: string;
+  subtitle?: string;
   display_name: string;
   author_link: string;
   date: string;
@@ -27,22 +28,22 @@ const PublishDate = ({ date, styles }: { date: string; styles?: string }) => {
     </div>
   );
 };
-const Title = (title: string) => {
-  return <h3 className="text-purple-700">{title}</h3>;
-};
 
 function ArticleCard(props: ArticleCardProps) {
   // Select fallback image based on index, cycling through available images
   const fallbackImage = FALLBACK_IMAGES[(props.index || 0) % FALLBACK_IMAGES.length];
   
-  // Sanitizes HTML and converts it to plain text
-  const sanitizeHtml = (html: string) => {
-    if (!html) return html;
+  // Sanitizes HTML and converts it to plain text safely
+  const sanitizeHtml = (html: string | undefined) => {
+    if (!html) return '';
     const div = document.createElement("div");
     div.innerHTML = html;
     return div.textContent || div.innerText || "";
   };
-  const abbrSubtitle = sanitizeHtml(props.subtitle).trim().split(' ').slice(0, 32).join(' ').concat('...');
+
+  const cleanSubtitle = sanitizeHtml(props.subtitle);
+  const abbrSubtitle = cleanSubtitle ? cleanSubtitle.trim().split(' ').slice(0, 32).join(' ').concat('...') : '';
+
   if (props.altLayout) {
     return (
       <article className="my-4 max-w-2xl shadow-lg">
@@ -59,13 +60,15 @@ function ArticleCard(props: ArticleCardProps) {
               </h3>
               <PublishDate date={props.date} styles="col-start-1 order-1 row-start-1 z-10" />
             </div>
-            <img
-              src={props.imgSrc || fallbackImage}
-              className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
-            />
+            <div className="col-start-1 row-start-1 h-48 w-full overflow-hidden rounded-sm lg:w-80 flex items-center justify-center p-2">
+              <img
+                src={props.imgSrc || fallbackImage}
+                className="h-full w-full object-contain"
+              />
+            </div>
           </div>
           <div className="max-w-sm items-center gap-2 self-center p-2 pr-4">
-            {parse(abbrSubtitle)}
+            {abbrSubtitle ? parse(abbrSubtitle) : null}
             <p className="mt-2 text-purple-700">
               By: <a href={props.author_link}>{props.display_name}</a>
             </p>
@@ -77,9 +80,16 @@ function ArticleCard(props: ArticleCardProps) {
   // Normal Layout
   else
     return (
-      <article className="my-4 max-w-sm p-4">
-        <div className="grid">
-          <h3 className="w-10/12 rounded-sm bg-gradient-radial from-purple-700 to-purple-900 px-2 py-1 text-white shadow-sm">
+      <article className="my-4 max-w-sm p-4 flex flex-col h-full">
+        {/* Image Container with fixed height and uniform object-contain */}
+        <div className="relative h-48 w-full overflow-hidden rounded-sm flex items-center justify-center p-2">
+          <PublishDate date={props.date} styles="absolute top-2 left-2 z-10" />
+          <img src={props.imgSrc || fallbackImage} className="h-full w-full object-contain" />
+        </div>
+
+        {/* Title Container with fixed height (h-28) to prevent multi-line overlap */}
+        <div className="mt-3 h-28 flex items-start">
+          <h3 className="w-10/12 rounded-sm bg-gradient-radial from-purple-700 to-purple-900 px-2 py-1 text-white shadow-sm z-20">
             <a
               href={props.path}
               target="_blank"
@@ -87,13 +97,17 @@ function ArticleCard(props: ArticleCardProps) {
               {sanitizeHtml(props.title)}
             </a>
           </h3>
-          {parse(abbrSubtitle)}
-          <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
-          <img src={props.imgSrc || fallbackImage} className="object-fit col-start-1 row-start-1 rounded-sm" />
-          <p className="text-purple-700">
-            By: <a href={props.author_link}>{props.display_name}</a>
-          </p>
         </div>
+
+        {/* Subtitle text with clean spacing */}
+        <div className="mt-3 text-gray-700 dark:text-gray-300">
+          {abbrSubtitle ? parse(abbrSubtitle) : null}
+        </div>
+
+        {/* Author Footer locked to the bottom via mt-auto */}
+        <p className="mt-auto pt-4 text-purple-700 font-medium">
+          By: <a href={props.author_link} className="hover:underline">{props.display_name}</a>
+        </p>
       </article>
     );
 }


### PR DESCRIPTION
Fixes #623

#### Concisely describe the change
Aligned title banners, image containers, text blocks, and author footers in the Latest Podman News section (`ArticleCard` and `BlogArticlesList`). Standardized container heights and image fitting (`object-contain`) to ensure uniform layout across cards.

#### Before screenshot / screen recording
<img width="2618" height="714" alt="image" src="https://github.com/user-attachments/assets/792ccc71-f417-423c-be98-871626f8ae6e" />


#### After screenshot / screen recording
<img width="1502" height="726" alt="image" src="https://github.com/user-attachments/assets/e16b547f-6c01-40ab-8209-aabe31222191" />

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #623` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)