### PR TITLE
fix: align blog article thumbnail heights for consistent layout

### DIFF
--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -61,7 +61,7 @@ function ArticleCard(props: ArticleCardProps) {
             </div>
             <img
               src={props.imgSrc || fallbackImage}
-              className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
+              className="col-start-1 row-start-1 h-72 w-full rounded-sm object-cover object-top lg:w-80"
             />
           </div>
           <div className="max-w-sm items-center gap-2 self-center p-2 pr-4">
@@ -89,7 +89,7 @@ function ArticleCard(props: ArticleCardProps) {
           </h3>
           {parse(abbrSubtitle)}
           <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
-          <img src={props.imgSrc || fallbackImage} className="object-fit col-start-1 row-start-1 rounded-sm" />
+          <img src={props.imgSrc || fallbackImage} className="col-start-1 row-start-1 h-72 w-full rounded-sm object-cover object-top" />
           <p className="text-purple-700">
             By: <a href={props.author_link}>{props.display_name}</a>
           </p>


### PR DESCRIPTION

This PR fixes the misaligned  banners in the "Latest Podman News" section 

## What was the issue?
The blog article thumbnails had varying heights because the images come in different aspect ratios. This caused different vertical positions, creating a jagged, inconsistent layout.

## What changed?
1.  Set a fixed height (`h-72`) on all thumbnail images
2. Applied `object-cover` with `object-top` positioning to maintain aspect ratios while filling the container


## Before 
<img width="1469" height="799" alt="image" src="https://github.com/user-attachments/assets/fad8a19e-a7b1-42a2-b4c2-c4ebc4ad85f5" />
<img width="1470" height="803" alt="image" src="https://github.com/user-attachments/assets/b304cf88-80a8-4b0d-b879-c28118980420" />


## After 
<img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/7e0012d5-27f3-4b2f-a372-a17bbd47742b" />
<img width="1470" height="801" alt="image" src="https://github.com/user-attachments/assets/d8291a27-bab8-4377-bbb1-602ad64096ed" />






Closes #623 