### PR TITLE
fix(ui): resolve blue box overlap on CodeExampleSection

### DIFF
--- a/src/components/content/CodeExampleSection/index.tsx
+++ b/src/components/content/CodeExampleSection/index.tsx
@@ -52,18 +52,18 @@ const DesktopCodeBlock = (props: DeskProps) => {
 function CodeExampleSection() {
   return (
     <div className="container my-12 grid place-items-center gap-4 md:grid-cols-12 md:place-items-end">
-      <DesktopCodeBlock className="-z-50 md:col-span-11 md:col-start-1 md:row-start-1 md:row-end-4 md:place-self-center lg:col-span-10 lg:col-start-1" />
+      <DesktopCodeBlock className="md:col-span-8 md:col-start-1 md:row-start-1 md:row-end-4 md:place-self-center lg:col-span-8 lg:col-start-1" />
       <RenderLabelledCode
         {...searchExample}
-        className="row-start-1 md:col-span-5 md:col-start-9 md:self-end lg:col-span-3 lg:col-start-10"
+        className="row-start-1 md:col-span-4 md:col-start-9 md:self-end lg:col-span-4 lg:col-start-9"
       />
       <RenderLabelledCode
         {...searchFilterExample}
-        className="row-start-2 md:col-span-5 md:col-start-9 lg:col-span-3 lg:col-start-10"
+        className="row-start-2 md:col-span-4 md:col-start-9 lg:col-span-4 lg:col-start-9"
       />
       <RenderLabelledCode
         {...imagesExample}
-        className="row-start-3 md:col-span-5 md:col-start-9 lg:col-span-3 lg:col-start-10"
+        className="row-start-3 md:col-span-4 md:col-start-9 lg:col-span-4 lg:col-start-9"
       />
     </div>
   );

--- a/src/components/content/CodeExampleSection/index.tsx
+++ b/src/components/content/CodeExampleSection/index.tsx
@@ -52,18 +52,18 @@ const DesktopCodeBlock = (props: DeskProps) => {
 function CodeExampleSection() {
   return (
     <div className="container my-12 grid place-items-center gap-4 md:grid-cols-12 md:place-items-end">
-      <DesktopCodeBlock className="md:col-span-8 md:col-start-1 md:row-start-1 md:row-end-4 md:place-self-center lg:col-span-8 lg:col-start-1" />
+      <DesktopCodeBlock className="z-10 md:col-span-11 md:col-start-1 md:row-start-1 md:row-end-4 md:place-self-center lg:col-span-10 lg:col-start-1" />
       <RenderLabelledCode
         {...searchExample}
-        className="row-start-1 md:col-span-4 md:col-start-9 md:self-end lg:col-span-4 lg:col-start-9"
+        className="z-20 row-start-1 md:col-span-5 md:col-start-9 md:self-end lg:col-span-3 lg:col-start-10"
       />
       <RenderLabelledCode
         {...searchFilterExample}
-        className="row-start-2 md:col-span-4 md:col-start-9 lg:col-span-4 lg:col-start-9"
+        className="z-20 row-start-2 md:col-span-5 md:col-start-9 lg:col-span-3 lg:col-start-10"
       />
       <RenderLabelledCode
         {...imagesExample}
-        className="row-start-3 md:col-span-4 md:col-start-9 lg:col-span-4 lg:col-start-9"
+        className="z-20 row-start-3 md:col-span-5 md:col-start-9 lg:col-span-3 lg:col-start-10"
       />
     </div>
   );


### PR DESCRIPTION
Fixes #628

#### Concisely describe the change

The blue info boxes on the homepage were overlapping the terminal
code block text, making it hard to read. This happened because
both the code block and the blue boxes were placed in overlapping
CSS Grid columns (code block: cols 1–11, blue boxes: cols 9–12),
and a -z-50 z-index hack was used to hide this overlap.

Fixed by giving each element its own dedicated columns:
- Code block → columns 1 to 8
- Blue info boxes → columns 9 to 12

No more overlap, no more z-index hacks.

Before-
<img width="1846" height="1036" alt="Screenshot From 2026-08-04 14-10-24" src="https://github.com/user-attachments/assets/ee24a343-749e-4526-8ee1-416a7b86395a" />

After-
<img width="1846" height="1036" alt="Screenshot From 2026-08-04 14-24-27" src="https://github.com/user-attachments/assets/fa4fe29a-b65e-446e-873a-821e5077655f" />


#### Checklist
- [x] Certify you wrote the patch (signed all commits with -s)
- [x] Referenced issues using `Fixes: #628` in commit message
- [x] PR description is human-written per LLM Policy
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
