### PR TITLE
Fix testimonial slider clipping and card width inconsistency

### DIFF
--- a/src/components/content/TestimonialSection/index.tsx
+++ b/src/components/content/TestimonialSection/index.tsx
@@ -33,12 +33,14 @@ function TestimonialSection() {
         </button>
         <div
           id="slider"
-          className="mx-auto flex h-full w-full justify-center overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar">
-          {testimonials.map((testimonial, index) => {
-            return <Testimonial key={index} {...testimonial} />;
-          })}
-        </div>
-        <button
+          className="mx-auto flex h-full w-full overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar">
+          <div className="mx-auto inline-flex">
+            {testimonials.map((testimonial, index) => {
+              return <Testimonial key={index} {...testimonial} />;
+            })}
+          </div>
+          </div>
+          <button
           type="button"
           onClick={slideRight}
           className="hidden sm:block xl:hidden"
@@ -48,6 +50,7 @@ function TestimonialSection() {
             className="dark:hover-text-purple-700 text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100"
           />
         </button>
+        
       </div>
     </section>
   );

--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -14,7 +14,7 @@ type TestimonialProps = {
 
 function Testimonial(props: TestimonialProps) {
   return (
-    <article className="flex flex-col mx-2 my-4 max-w-sm rounded-sm bg-white p-4 shadow-lg dark:bg-gray-900">
+    <article className="flex flex-col mx-2 my-4 w-[300px] min-w-[300px] max-w-sm rounded-sm bg-white p-4 shadow-lg dark:bg-gray-900 sm:w-[340px] sm:min-w-[340px]">
       <div className="flex items-center gap-3 mb-4">
         <div className="m-2">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes #573, #632

Problem
The testimonial section has two issues affecting the homepage:

- first card gets clipped at 90–100% zoom and on narrower viewports
- cards resize based on content length, creating inconsistent widths

**Before:** 

https://github.com/user-attachments/assets/27adc2e3-1cda-4f77-8ad5-bb6c466ac69d




**After:** 

https://github.com/user-attachments/assets/491ec47f-b908-49cc-83f6-b9b8784319ec



Root Cause
The slider container uses justify-center with overflow-x-scroll, which pushes content past the scroll origin i.e the browser can't scroll back to the first card. Additionally, cards lack fixed widths so they size based on how much text they contain.

Changes
TestimonialSection/index.tsx:
- Removed justify-center from the scroll container (root cause of the clipping)
- Added an inner inline-flex mx-auto wrapper so cards still center when they all fit on screen, but don't clip when they overflow

Testimonial/index.tsx:
- Added fixed widths (w-[300px] / sm:w-[340px]) for consistent card sizing





