### PR TITLE
Misspelled Tailwind Class Names justify-content-center and align-items-center

### DIFF
--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -192,7 +192,7 @@ function CommunityMeetingsCardGrid({ cards }) {
   }
 
   return (
-    <div className="justify-content-center align-items-center custom-card-grid-root flex">
+    <div className="justify-center items-center custom-card-grid-root flex">
       {cards.map((card: CommunityMeetingsCardProps, index: number) => {
         let meetingsData = index == 1 ? CabalMeetingsData : communityMeetingsData;
         return (


### PR DESCRIPTION
Closes #641 
* **File Reference:** [CommunityMeetingsCardGrid/index.tsx](file:///c:/Users/Hp/podman.io/src/components/layout/CommunityMeetingsCardGrid/index.tsx#L195)
* **Code Pointer:**
  ```typescript
  <div className="justify-content-center align-items-center custom-card-grid-root flex">
  ```
* **Technical Reason & Impact:** The developer used the full CSS property names (`justify-content-center` and `align-items-center`) instead of (`justify-center` and `items-center`). Since these classes do not exist in Tailwind's stylesheet, the browser ignores them, resulting in layout misalignment and centering failures in the meetings grid.
