### PR TITLE
Missing alt Attribute on Podman Desktop Logo

### DIFF
--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -47,7 +47,7 @@ const PodmanDesktopSection = () => {
       </div>
       <div className="container flex flex-col md:flex-row items-center">
         <div id="imgdiv" className="mx-auto w-full md:w-auto">
-          <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" />
+          <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" alt="Podman Desktop Logo" />
         </div>
         <div className="md:w-1/2 xl:w-3/4">
           <p className="my-8 align-middle text-2xl leading-relaxed">
@@ -158,7 +158,7 @@ const PodmanCLISection = () => {
       </div>
       <div className="container mb-4 grid gap-2 lg:grid-cols-3">
         <div className="mx-auto">
-          <img className="max-h-[200px]" src="images/optimized/podman-selkie-385w-358h.webp" />
+          <img className="max-h-[200px]" src="images/optimized/podman-selkie-385w-358h.webp" alt="Podman Selkie Mascot" />
         </div>
         <div className="col-span-2">
           <p className="my-8 align-middle text-2xl leading-relaxed">


### PR DESCRIPTION



* **File Reference:** [features.tsx](file:///c:/Users/Hp/podman.io/src/pages/features.tsx)
* **Code Pointer:**
  ```typescript
  <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" />
  ```

* **Technical Reason & Impact:** An `<img>` tag must include an `alt` attribute. Missing it violates WCAG 2.1 accessibility specifications, forcing screen readers to read the filename, creating a poor screen-reader experience.
* **How to Reproduce:**
  1. Inspect the Podman Desktop logo on the `/features` page.
  2. Observe that there is no `alt="..."` attribute defined on the logo image element.

---
