### PR TITLE
Created a fully functional downloads page.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,7 @@ const config = {
         items: [
           { to: 'features', label: 'Features', position: 'right' },
           { to: 'get-started', label: 'Get Started', position: 'right' },
+          { to: 'downloads', label: 'Downloads', position: 'right' },
           { to: 'community', label: 'Community', position: 'right' },
           {
             to: 'https://blog.podman.io',

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -5,23 +5,13 @@ import Button from '@site/src/components/utilities/Button';
 import DropdownButton from '@site/src/components/utilities/DropdownButton';
 import Link from '@site/src/components/utilities/Link';
 import WaveBorder from '@site/src/components/shapes/WaveBorder';
-import operatingSystemData from './installOptions';
+import operatingSystemData, { detectOperatingSystem } from './installOptions';
 type InstallOptionProps = Card & {
   icon: string;
   option?: React.ReactNode;
   path: string;
   third?: { title: string; subtitle: string; icon: string; path: string };
   other?: { path: string; text: string; subtext: string };
-};
-
-const detectOperatingSystem = () => {
-  const userAgent = window.navigator.userAgent.toLowerCase().split(' ');
-  if (userAgent.find(item => item.includes('windows'))) {
-    return 'windows';
-  } else if (userAgent.find(item => item.includes('macintosh'))) {
-    return 'mac';
-  }
-  return 'linux';
 };
 
 function returnOperatingSystemData() {

--- a/src/components/layout/HeroHeader/installOptions.ts
+++ b/src/components/layout/HeroHeader/installOptions.ts
@@ -1,4 +1,15 @@
 import { LATEST_VERSION, LATEST_DESKTOP_VERSION } from '@site/static/data/global';
+
+export const detectOperatingSystem = () => {
+  const userAgent = window.navigator.userAgent.toLowerCase().split(' ');
+  if (userAgent.find(item => item.includes('windows'))) {
+    return 'windows';
+  } else if (userAgent.find(item => item.includes('macintosh'))) {
+    return 'mac';
+  }
+  return 'linux';
+};
+
 const operatingSystemData = [
   {
     id: 'windows',
@@ -24,7 +35,7 @@ const operatingSystemData = [
       path: `https://github.com/podman-container-tools/podman/releases/download/v${LATEST_VERSION}/podman-installer-windows-arm64.msi`,
     },
     other: {
-      path: 'docs/installation',
+      path: 'downloads',
       text: 'Other Install Options',
     },
   },
@@ -44,7 +55,7 @@ const operatingSystemData = [
       path: `https://github.com/podman-container-tools/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-arm64.pkg`,
     },
     other: {
-      path: 'docs/installation',
+      path: 'downloads',
       text: 'Other Install Options',
     },
   },
@@ -63,7 +74,7 @@ const operatingSystemData = [
       path: `https://github.com/podman-desktop/podman-desktop/releases/download/v${LATEST_DESKTOP_VERSION}/podman-desktop-${LATEST_DESKTOP_VERSION}.flatpak`,
     },
     other: {
-      path: 'docs/installation',
+      path: 'downloads',
       text: 'Other Install Options',
     },
   },

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -101,6 +101,15 @@
   @apply text-blue-300 hover:text-blue-500
 }
 
+/* Below Infima's default breakpoint, footer columns stack full-width but
+   their left-aligned content leaves a large empty gap on the right.
+   Center each column so the empty space is balanced instead. */
+@media (max-width: 996px) {
+  .footer__col {
+    text-align: center;
+  }
+}
+
 .menu a {
   @apply no-underline;
 }

--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { Icon } from '@iconify/react';
+/* COMPONENTS */
+import PageHeader from '@site/src/components/layout/PageHeader';
+import SectionHeader from '@site/src/components/layout/SectionHeader';
+import Button from '@site/src/components/utilities/Button';
+/* PAGE DATA */
+import { header, platformTitles, otherOptions } from '@site/static/data/downloads';
+import operatingSystemData, { detectOperatingSystem } from '@site/src/components/layout/HeroHeader/installOptions';
+
+/* PAGE COMPONENTS */
+const DownloadLink = ({ title, subtitle, icon, path }) => (
+  <a
+    href={path}
+    className="flex items-center gap-4 rounded-md bg-gray-50 px-4 py-3 text-purple-900 no-underline transition duration-150 ease-linear hover:bg-purple-700 hover:text-white hover:no-underline dark:bg-gray-700 dark:text-white dark:hover:bg-purple-900">
+    <Icon icon={icon} className="text-3xl" />
+    <div>
+      <h4 className="m-0">{title}</h4>
+      <p className="m-0 text-sm">{subtitle}</p>
+    </div>
+  </a>
+);
+
+const PlatformCard = ({ os, detected }) => (
+  <div
+    className={`flex flex-col gap-3 rounded-md bg-white p-6 shadow-md dark:bg-gray-800 ${
+      detected ? 'outline outline-2 outline-purple-700 dark:outline-purple-500' : ''
+    }`}>
+    <div className="flex items-center justify-between">
+      <h3 className="m-0 text-purple-700 dark:text-purple-500">{platformTitles[os.id]}</h3>
+      {detected && (
+        <span className="rounded-full bg-purple-700 px-3 py-1 text-xs font-semibold text-white dark:bg-purple-500">
+          Detected
+        </span>
+      )}
+    </div>
+    <DownloadLink {...os.preferred} />
+    <DownloadLink {...os.alt} />
+    {os.third && <DownloadLink {...os.third} />}
+  </div>
+);
+
+const PlatformsSection = () => (
+  <section>
+    <SectionHeader title="Choose your platform" />
+    <div className="container my-8 grid gap-6 md:grid-cols-3">
+      <BrowserOnly
+        fallback={
+          <>
+            {operatingSystemData.map(os => (
+              <PlatformCard key={os.id} os={os} detected={false} />
+            ))}
+          </>
+        }>
+        {() => {
+          const detected = detectOperatingSystem();
+          return (
+            <>
+              {operatingSystemData.map(os => (
+                <PlatformCard key={os.id} os={os} detected={os.id === detected} />
+              ))}
+            </>
+          );
+        }}
+      </BrowserOnly>
+    </div>
+  </section>
+);
+
+const OtherOptionsSection = () => (
+  <section>
+    <SectionHeader title={otherOptions.title} description={otherOptions.subtitle} />
+    <div className="container mb-12 flex justify-center">
+      <Button as="link" text={otherOptions.button.text} path={otherOptions.button.path} icon={otherOptions.button.icon} />
+    </div>
+  </section>
+);
+
+/* PAGE CONTENT */
+function Downloads() {
+  return (
+    <Layout>
+      <PageHeader title={header.title} description={header.subtitle} />
+      <PlatformsSection />
+      <OtherOptionsSection />
+    </Layout>
+  );
+}
+
+export default Downloads;

--- a/static/data/downloads.ts
+++ b/static/data/downloads.ts
@@ -1,0 +1,23 @@
+const header = {
+  title: 'Download Podman',
+  subtitle:
+    'Get Podman CLI and Podman Desktop for your platform. We detect your operating system automatically, but every platform is listed below.',
+};
+
+const platformTitles: { [key: string]: string } = {
+  windows: 'Windows',
+  mac: 'macOS',
+  linux: 'Linux',
+};
+
+const otherOptions = {
+  title: 'Looking for something else?',
+  subtitle: 'Package manager installs, building from source, and remote installs are covered in the full installation docs.',
+  button: {
+    text: 'Installation Instructions',
+    path: 'docs/installation',
+    icon: 'fa6-solid:book',
+  },
+};
+
+export { header, platformTitles, otherOptions };


### PR DESCRIPTION
Related to #512 
#### Concisely describe the change

I added a dedicated download page so users no longer get redirected to https://podman.io/docs/installation when they click the **Other Install Options** button in the download menu. Instead, they are taken to a proper download page that includes all available download options. For additional guidance on downloading and installing Podman, I also added an **Installer Instructions** button that links to the relevant documentation.

#### Before screenshot / screen recording

Previously, clicking the **Other Install Options** button redirected users to this page:

<img width="3406" height="2048" alt="image" src="https://github.com/user-attachments/assets/1c80767c-48ed-4176-8ddc-91882e298baa" />

#### After screenshot / screen recording

Now, users are taken to a dedicated download page with all available download options:

<img width="3420" height="2076" alt="image" src="https://github.com/user-attachments/assets/b526eda3-4563-41db-b058-0d52075c7ab1" />

<img width="3414" height="2056" alt="image" src="https://github.com/user-attachments/assets/7aa7548d-97ad-4725-81c8-3a71d5b10f5c" />

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] The PR description, commit message, and GitHub comments are human-written, in accordance with the [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md).
