### PR TITLE
Refactor: Remove obsolete local /release path and link directly to Gi…

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,14 +33,6 @@ const config = {
         },
       };
     },
-    ['@docusaurus/plugin-content-blog',
-      {
-        showReadingTime: true,
-        routeBasePath: 'release',
-        id: 'release-anouncements',
-        path: './release',
-      },
-    ],
   ],
   presets: [
     [
@@ -153,6 +145,10 @@ const config = {
               {
                 label: 'Podman GitHub',
                 href: 'https://github.com/podman-container-tools/podman',
+              },
+              {
+                label: 'Podman Releases',
+                href: 'https://github.com/podman-container-tools/podman/releases',
               },
               {
                 label: 'Podman Desktop GitHub',


### PR DESCRIPTION
## Description

This PR removes the obsolete local `/release` page and updates the website to direct users to the official Podman GitHub Releases page.

### Changes

* Removed the secondary `@docusaurus/plugin-content-blog` configuration responsible for serving the `/release` route.
* Deleted the unused `release/` directory.
* Added a **Podman Releases** link in the website footer pointing to:

  * https://github.com/podman-container-tools/podman/releases

### Verification

* Searched the repository to ensure there are no remaining references to:

  * `/release`
  * `release-anouncements`
  * `./release`
* Verified the project builds successfully after the changes.
* No unrelated source files or blog posts were modified.

Fixes #634.
