### PR TITLE
fix(ui): replace outer p tag with div in CustomCard to prevent invalid HTML nesting

### DIFF
--- a/src/components/ui/CustomCard/index.tsx
+++ b/src/components/ui/CustomCard/index.tsx
@@ -30,9 +30,9 @@ function CardBody(props) {
   const { text } = props;
   return (
     <div className="mx-2 my-6 overflow-y-auto lg:my-8">
-      <p id="cardBody-parsed" className="text-gray-700 dark:text-gray-100">
+      <div id="cardBody-parsed" className="text-gray-700 dark:text-gray-100">
         <Markdown text={text} />
-      </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes #653
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Concisely describe the change
Replaced the outer `<p id="cardBody-parsed">` wrapper with a `<div>` in `src/components/ui/CustomCard/index.tsx.`

`Markdown` renders `ReactMarkdown`, which outputs block-level elements such as `<p>` for markdown content. Wrapping it inside another `<p>` produces invalid nested paragraph markup. Using a `<div>` preserves valid HTML while allowing markdown content to render correctly.

#### Before screenshot / screen recording

#### After screenshot / screen recording

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [ x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
