### PR TITLE
fix: improve type safety in PlayOnScroll and CommunityMeetingsCardGrid

### DIFF
--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -47,6 +47,26 @@ type SubcardGridProps = {
   date: string;
 };
 
+type MarkdownLinkProps = {
+  href?: string;
+};
+
+const isMarkdownLinkElement = (
+  node: React.ReactNode,
+): node is React.ReactElement<MarkdownLinkProps> => {
+  return React.isValidElement<MarkdownLinkProps>(node);
+};
+
+type MarkdownSectionProps = {
+  children?: React.ReactNode;
+};
+
+const isMarkdownSectionElement = (
+  node: React.ReactNode,
+): node is React.ReactElement<MarkdownSectionProps> => {
+  return React.isValidElement<MarkdownSectionProps>(node);
+};
+
 function toggleModalOpen(ref, handler) {
   useEffect(() => {
     const listener = event => {
@@ -91,11 +111,20 @@ function CommunityMeetingsCardGrid({ cards }) {
 
   const populateMeetings = (): void => {
     Object.values(markDownFiles)?.forEach(mdFile => {
-      let mdReader = mdFile?.default(useRef());
-      mdReader?.props?.children?.forEach(child => {
-        let field1: string = child?.props?.children?.[0];
-        let field2: object = child?.props?.children?.[1];
+      const mdReader = mdFile?.default({});
+      if (!isMarkdownSectionElement(mdReader)) {
+        return;
+      }
+
+      React.Children.forEach(mdReader.props.children, child => {
+        if (!isMarkdownSectionElement(child)) {
+          return;
+        }
+
+        const [field1, field2] = React.Children.toArray(child.props.children);
         if (typeof field1 == 'string' && (field1.includes('BlueJeans') || field1.includes('Video'))) {
+          const recordingLink = isMarkdownLinkElement(field2) ? field2.props.href : undefined;
+
           if (mdFile?.contentTitle?.includes('Cabal')) {
             cabalDropdownOptions.unshift({
               date: (mdFile?.toc?.[0]?.value as string).split(/[0-9]{2}:[0-9]{2}/)[0],
@@ -105,7 +134,7 @@ function CommunityMeetingsCardGrid({ cards }) {
                 text: 'Meeting Minutes',
               },
               meeting_recording: {
-                link: field2?.props?.href,
+                link: recordingLink,
                 text: 'Watch Recording',
               },
             });
@@ -118,7 +147,7 @@ function CommunityMeetingsCardGrid({ cards }) {
                 text: 'Meeting Minutes',
               },
               meeting_recording: {
-                link: field2?.props?.href,
+                link: recordingLink,
                 text: 'Watch Recording',
               },
             });

--- a/src/components/utilities/PlayOnScroll/index.tsx
+++ b/src/components/utilities/PlayOnScroll/index.tsx
@@ -1,45 +1,45 @@
 import React, { useRef, useEffect } from 'react';
 
 interface VideoProps {
-    url: string;
-    vidFormat?: string;
-    styles?: string;
-    posterImg?: string;
-  }
+  url: string;
+  vidFormat?: string;
+  styles?: string;
+  posterImg?: string;
+}
 
-const PlayOnScroll: React.FC = (props: VideoProps) => {
-    const videoRef = useRef<HTMLVideoElement>(null);
-  
-    useEffect(() => {
-      const handleScroll = () => {
-        if (videoRef.current) {
-          const rect = videoRef.current.getBoundingClientRect();
-          const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
-          
-          if (isFullyVisible) {
-            videoRef.current.play();
-          } else {
-            videoRef.current.pause();
-          }
+const PlayOnScroll: React.FC<VideoProps> = props => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (videoRef.current) {
+        const rect = videoRef.current.getBoundingClientRect();
+        const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+
+        if (isFullyVisible) {
+          videoRef.current.play();
+        } else {
+          videoRef.current.pause();
         }
-      };
-  
-      window.addEventListener('scroll', handleScroll);
-      
-      return () => {
-        window.removeEventListener('scroll', handleScroll);
-      };
-    }, []);
-  
-    return (
-      <div>
-        <video className={props.styles} ref={videoRef} poster={props.posterImg} autoPlay>
-          <source src={props.url} type={props.vidFormat} />
-          {/* Add additional source elements for different video formats if needed */}
-          Your browser does not support the video tag.
-        </video>
-      </div>
-    );
-  };
-  
-  export default PlayOnScroll;
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return (
+    <div>
+      <video className={props.styles} ref={videoRef} poster={props.posterImg} autoPlay>
+        <source src={props.url} type={props.vidFormat} />
+        {/* Add additional source elements for different video formats if needed */}
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+};
+
+export default PlayOnScroll;


### PR DESCRIPTION
## Description 

Resolve two type-safety TypeScript problems preventing yarn typecheck from passing.

1] Add a PlayOnScroll type using VideoProps that already exists for proper prop recognition in features.tsx
2] Resolve type-safety problems in CommunityMeetingsCardGrid by appropriately narrowing parsed markdown nodes when accessing properties.
3] Maintain existing functionality and link extraction of meeting recordings.

fixes #661 

#### Before screenshot / screen recording

Not applicable. This PR contains type-safety and build-quality fixes only; there are no intended UI changes.


#### After screenshot / screen recording

Not applicable. No visual or runtime behavior was intentionally changed.

#### Checklist



- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.

- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
