### PR TITLE
docs: fix broken link, grammar, and typos across documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _Text and Images_
 - Most page data is stored in `static/data/<page-name>`
   - It is set up so that you can use markdown in the strings for much of the content.
     - _If the markdown syntax renders, it needs to be passed into the `Markdown` component (in `components/utilities/`)_
-- files like `static/data/globa.ts`, `static/data/testimonials.ts`, and `static/data/meetings.ts` are meant to make it easier for people with limited coding experience to be able to quickly update specific and regularly changing content.
+- files like `static/data/global.ts`, `static/data/testimonials.ts`, and `static/data/meetings.ts` are meant to make it easier for people with limited coding experience to be able to quickly update specific and regularly changing content.
   - **note**: the `papaparse` library has been added for switching to `.csv` files in the future.
 
 ### Page Style and Structure
@@ -79,7 +79,7 @@ _Text and Images_
 
 ### Typescript
 
-- a bunch of base types are found in `typs.d.ts`
+- a bunch of base types are found in `types.d.ts`
   - these are primarily for props. Kept minimal by design and then extended when needed (primarily with style props)
 
 ### Assets
@@ -91,7 +91,7 @@ _Text and Images_
 - changes to the default styles are in `src/assets/css/main.css` in the following order:
   - imports
   - docusaurus root colors
-  - docusarus component style changes
+  - docusaurus component style changes
   - font configuration
 - default fonts are set inside `@layer base{}` in `main.css` using tailwind's **@apply** syntax
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ The documentation for Podman is located
 ## Installing Podman
 
 For installing or building Podman, please see the
-[installation instructions](docs/installation).
+[installation instructions](installation.md).
 
 ## Familiarizing yourself with Podman
 
@@ -101,7 +101,7 @@ podman ps
 ### Testing the httpd container
 
 As you are able to see, the container does not have an IP Address assigned. The
-container is reachable via it's published port on your local machine.
+container is reachable via its published port on your local machine.
 
 ```bash
 curl http://localhost:8080
@@ -134,7 +134,7 @@ podman inspect -l | grep IPAddress
 **Note**: The `-l` is a convenience argument for **latest container**. Instead of this short argument, you can
 also use the container's ID, container's name or the long argument (`--latest`).
 
-**Note**: If you are running remote Podman client, including Mac and Windows
+**Note**: If you are running a remote Podman client, including Mac and Windows
 (excluding WSL2) machines, the `-l` option is not available.
 
 ### Viewing the container's logs

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ service running in the Machine VM.
      <summary>Use the Installer (Recommended)</summary>
 
      Podman can be downloaded from the [Podman.io](https://podman.io) website.
-     You can get binaries and a pkginstaller from our [GitHub release page](https://github.com/containers/podman/releases).
+     You can get binaries and a pkg installer from our [GitHub release page](https://github.com/containers/podman/releases).
 
      </details>
 
@@ -95,7 +95,7 @@ For further details, please refer to the instructions on the [Alpine Linux wiki]
 
 #### [CentOS Stream](https://www.centos.org)
 
-Podman is available in the default in the AppStream repo for CentOS Stream 9+.
+Podman is available by default in the AppStream repo for CentOS Stream 9+.
 
 ```bash
 sudo dnf -y install podman


### PR DESCRIPTION
Fixes #667

This PR resolves several typos and a broken relative link across the documentation and README.

### Changes Included:

**`docs/index.md`**
- **Fixed broken link:** Changed `[installation instructions](docs/installation)` to `(installation.md)` on line 22 to prevent Docusaurus from routing incorrectly to `/docs/docs/installation`.
- **Fixed grammar:** Corrected the possessive pronoun typo `"it's published port"` to `"its published port"` on line 104.
- **Fixed grammar:** Added missing article to change `"running remote Podman client"` to `"running a remote Podman client"` on line 137.

**`docs/installation.md`**
- **Fixed typo:** Added a missing space to change `"pkginstaller"` to `"pkg installer"` on line 33.
- **Fixed grammar:** Removed duplicate preposition to change `"in the default in the"` to `"by default in the"` on line 98.

**`README.md`**
- **Fixed typos:** Corrected misspelled file references:
  - `"globa.ts"` -> `"global.ts"` (Line 59)
  - `"typs.d.ts"` -> `"types.d.ts"` (Line 82)
  - `"docusarus"` -> `"docusaurus"` (Line 94)
