### PR TITLE
fix: correct typeof window check in NotFound component for SSR

### DIFF
--- a/src/theme/NotFound.tsx
+++ b/src/theme/NotFound.tsx
@@ -11,7 +11,7 @@ export default function NotFound(): JSX.Element {
   const [searchLink, setSearchLink] = useState("");
 
   useEffect(() => {
-    if (typeof window !== undefined) {
+    if (typeof window !== 'undefined') {
       setCurrUrl(window.location.href);
     }
   }, []);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Concisely describe the change

Fixes #679 
The NotFound component incorrectly checked for the window object using `typeof window !== undefined`. Because `typeof` always returns a string, this check was always evaluating to true, comparing the string "undefined" to the primitive `undefined`.

This commit updates the check to compare against the string `'undefined'`, preventing ReferenceErrors when the component is evaluated during Server Side Rendering (SSR) in Docusaurus.

#### Before screenshot / screen recording
N/A - This is a backend/SSR logic fix, so there are no visual UI changes.

#### After screenshot / screen recording
N/A - This is a backend/SSR logic fix, so there are no visual UI changes.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs) for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
