### PR TITLE
fix: remove DOM dependency from ArticleCard

### DIFF
--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import parse from 'html-react-parser';
+import htmlToText from '@site/src/utils/htmlToText';
 type ArticleCardProps = {
   title: string;
   subtitle: string;
@@ -27,22 +27,18 @@ const PublishDate = ({ date, styles }: { date: string; styles?: string }) => {
     </div>
   );
 };
-const Title = (title: string) => {
-  return <h3 className="text-purple-700">{title}</h3>;
-};
-
 function ArticleCard(props: ArticleCardProps) {
   // Select fallback image based on index, cycling through available images
   const fallbackImage = FALLBACK_IMAGES[(props.index || 0) % FALLBACK_IMAGES.length];
-  
-  // Sanitizes HTML and converts it to plain text
-  const sanitizeHtml = (html: string) => {
-    if (!html) return html;
-    const div = document.createElement("div");
-    div.innerHTML = html;
-    return div.textContent || div.innerText || "";
+  const subtitleStyle: React.CSSProperties = {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 3,
+    overflow: 'hidden',
   };
-  const abbrSubtitle = sanitizeHtml(props.subtitle).trim().split(' ').slice(0, 32).join(' ').concat('...');
+
+  const titleContent = htmlToText(props.title);
+  const subtitleContent = htmlToText(props.subtitle);
   if (props.altLayout) {
     return (
       <article className="my-4 max-w-2xl shadow-lg">
@@ -54,7 +50,7 @@ function ArticleCard(props: ArticleCardProps) {
                   href={props.path}
                   target="_blank"
                   className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
-                  {sanitizeHtml(props.title)}
+                  {titleContent}
                 </a>
               </h3>
               <PublishDate date={props.date} styles="col-start-1 order-1 row-start-1 z-10" />
@@ -64,8 +60,8 @@ function ArticleCard(props: ArticleCardProps) {
               className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
             />
           </div>
-          <div className="max-w-sm items-center gap-2 self-center p-2 pr-4">
-            {parse(abbrSubtitle)}
+          <div className="max-w-sm items-center gap-2 self-center p-2 pr-4" style={subtitleStyle}>
+            {subtitleContent}
             <p className="mt-2 text-purple-700">
               By: <a href={props.author_link}>{props.display_name}</a>
             </p>
@@ -84,10 +80,10 @@ function ArticleCard(props: ArticleCardProps) {
               href={props.path}
               target="_blank"
               className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
-              {sanitizeHtml(props.title)}
+              {titleContent}
             </a>
           </h3>
-          {parse(abbrSubtitle)}
+          <div style={subtitleStyle}>{subtitleContent}</div>
           <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
           <img src={props.imgSrc || fallbackImage} className="object-fit col-start-1 row-start-1 rounded-sm" />
           <p className="text-purple-700">

--- a/src/utils/htmlToText.ts
+++ b/src/utils/htmlToText.ts
@@ -1,0 +1,26 @@
+import React from 'react';
+import parse from 'html-react-parser';
+
+const collectText = (node: React.ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(collectText).join('');
+  }
+
+  if (React.isValidElement(node)) {
+    return collectText(node.props.children);
+  }
+
+  return '';
+};
+
+export default function htmlToText(html: string): string {
+  if (!html) {
+    return '';
+  }
+
+  return collectText(parse(html));
+}


### PR DESCRIPTION
Fixes: #683

Removed the browser-dependent document.createElement() usage from ArticleCard and replaced the HTML-to-text conversion with an SSR-safe utility using the existing html-react-parser dependency. This allows ArticleCard to render during Docusaurus server-side/static rendering without requiring browser APIs.

####Before Screenshot
Terminal output showing the Docusaurus build failing while rendering /ssrissue because document is unavailable.
<img width="945" height="395" alt="Screenshot 2026-08-13 193752" src="https://github.com/user-attachments/assets/79dd94a0-1f93-4c80-85d8-980f17adcfe4" />

Test File
<img width="980" height="610" alt="Screenshot 2026-08-13 194040" src="https://github.com/user-attachments/assets/069befb5-0ff1-44f0-b27c-71341ac6c148" />

#### After Screenshot

Terminal output showing the Docusaurus build completing successfully after removing the browser DOM dependency from ArticleCard.
<img width="983" height="434" alt="Screenshot 2026-08-14 161432" src="https://github.com/user-attachments/assets/8f9d3874-5895-49e2-8770-de23ffd5fae9" />

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x]  Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`). The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x]  Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x]  PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
