### PR TITLE
fix: make community meetings dropdown keyboard accessible

### DIFF
--- a/src/components/utilities/DropDown/index.tsx
+++ b/src/components/utilities/DropDown/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Icon } from '@iconify/react';
 
 import './styles.css';
@@ -26,22 +26,41 @@ function toggleDropdown(ref, handler) {
   }, [ref, handler]);
 }
 
+function closeOnEscape(handler) {
+  useEffect(() => {
+    const listener = event => {
+      if (event.key === 'Escape') {
+        handler();
+      }
+    };
+    document.addEventListener('keydown', listener);
+    return () => document.removeEventListener('keydown', listener);
+  }, [handler]);
+}
+
 function Dropdown(props: DropdownProps) {
   const { dropdownRef } = props;
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const optionsId = useRef(`dropdown-options-${Math.random().toString(36).slice(2)}`).current;
   toggleDropdown(dropdownRef, () => setIsOpen(false));
+  closeOnEscape(() => setIsOpen(false));
   return (
     <div ref={dropdownRef}>
-      <div
+      <button
+        type="button"
         data-dropdown-toggle="dropdown"
+        aria-expanded={isOpen}
+        aria-controls={optionsId}
         onClick={() => setIsOpen(prev => !prev)}
-        className="my-2 flex cursor-pointer items-center gap-1 py-2 pl-12 font-bold text-purple-700 dark:text-purple-500">
+        className="my-2 flex items-center gap-1 py-2 pl-12 font-bold text-purple-700 dark:text-purple-500">
         <div className={`transition duration-150 ease-linear ${isOpen && 'rotate-90'}`}>
           <Icon icon="bi:caret-right-square-fill" />
         </div>
         <span>{props.text}</span>
-      </div>
-      <div className="dropdown-options absolute mt-2 flex flex-col overflow-y-auto overflow-x-hidden shadow-md scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-900 md:max-h-full lg:max-h-96">
+      </button>
+      <div
+        id={optionsId}
+        className="dropdown-options absolute mt-2 flex flex-col overflow-y-auto overflow-x-hidden shadow-md scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-900 md:max-h-full lg:max-h-96">
         {isOpen && props?.options.map(option => option)}
       </div>
     </div>


### PR DESCRIPTION
### What this does

The community meetings dropdown (`src/components/utilities/DropDown`) used a clickable `<div>` for its toggle, so it couldn't be reached or operated with the keyboard, and wasn't exposed as an interactive control to screen readers.

- Replaced the `<div>` toggle with a `<button>`, matching the pattern  already used in the sibling `DropdownButton` component.
- Added `aria-expanded` and `aria-controls` so assistive tech can tell  when the options panel is open.
- Added an Escape key handler to close the dropdown.

### Testing

- `yarn typecheck` and `yarn build` both pass.
- Manually checked the community meetings dropdown still opens and closes correctly with both mouse and keyboard.

Fixes #687 

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [ x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
