### PR TITLE
fix: restore meeting notes links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,6 +41,16 @@ const config = {
         path: './release',
       },
     ],
+    [
+    '@docusaurus/plugin-content-docs',
+      {
+        id: 'meeting-notes',
+        path: './static/data/meetings/notes',
+        routeBasePath: 'community/meeting/notes',
+        include: ['**/index.md'],
+        sidebarPath: false,
+      },
+    ],
   ],
   presets: [
     [

--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -1,9 +1,8 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useRef } from 'react';
 import CustomCard from '@site/src/components/ui/CustomCard';
 import SubcardGrid from '@site/src/components/layout/SubcardGrid';
 import SectionHeader from '@site/src/components/layout/SectionHeader';
 import Dropdown from '@site/src/components/utilities/DropDown';
-import CloseIcon from '@site/src/components/shapes/CloseIcon';
 import * as markDownFiles from '@site/static/data/meetings/notes/index'; // ToDo: Lazy load these files
 
 import './styles.css';
@@ -29,16 +28,13 @@ type DropdownOptionProps = {
   };
   meeting_minutes: {
     text: string;
-    markDown: ReactNode;
-    modalHeaderData?: string;
+    path: string;
   };
 };
 
 type SubcardButtonProps = {
   text: string;
   path?: string;
-  markDown?: ReactNode;
-  modalHeaderData?: String;
 };
 
 type SubcardGridProps = {
@@ -47,47 +43,23 @@ type SubcardGridProps = {
   date: string;
 };
 
-function toggleModalOpen(ref, handler) {
-  useEffect(() => {
-    const listener = event => {
-      if (ref?.current?.contains(event.target)) {
-        return;
-      }
-      handler(event);
-    };
-    document.addEventListener('mousedown', listener);
-    document.addEventListener('touchstart', listener);
-    return () => {
-      document.removeEventListener('mousedown', listener);
-      document.removeEventListener('touchstart', listener);
-    };
-  }, [ref, handler]);
-}
 
 function CommunityMeetingsCardGrid({ cards }) {
   let cabalDropdownOptions: DropdownOptionProps[] = [];
   let MeetingDropdownOptions: DropdownOptionProps[] = [];
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [modalHeader, setModalHeader] = useState<ReactNode | undefined>(undefined);
-  const [meetinNotesMD, setMeetinNotesMD] = useState<ReactNode | undefined>(undefined);
   const meetingMinutesRef = [useRef(), useRef()];
-  const modalRef = useRef();
 
-  toggleModalOpen(modalRef, () => setIsModalOpen(false));
+const getMeetingPath = (value: string): string => {
+  const dateString = value.split(/[0-9]{2}:[0-9]{2}/)[0].trim();
+  const date = new Date(dateString);
 
-  const prepareModalHeader = (text: string, date: string) => {
-    const modalHeader: ReactNode = (
-      <div className="modal-header dark:bg-gray-500 dark:shadow-none">
-        <h3 className="modal-header-title dark:text-gray-900">{text}</h3>
-        <h3 className="modal-header-date dark:text-gray-900">{date}</h3>
-        <div className="cursor-pointer" onClick={() => setIsModalOpen(false)}>
-          <CloseIcon />
-        </div>
-      </div>
-    );
-    setModalHeader(modalHeader);
-  };
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `/community/meeting/notes/${year}-${month}-${day}/`;
+};
 
   const populateMeetings = (): void => {
     Object.values(markDownFiles)?.forEach(mdFile => {
@@ -100,8 +72,7 @@ function CommunityMeetingsCardGrid({ cards }) {
             cabalDropdownOptions.unshift({
               date: (mdFile?.toc?.[0]?.value as string).split(/[0-9]{2}:[0-9]{2}/)[0],
               meeting_minutes: {
-                markDown: mdReader,
-                modalHeaderData: mdFile['contentTitle'],
+                path: getMeetingPath(mdFile?.toc?.[0]?.value as string),
                 text: 'Meeting Minutes',
               },
               meeting_recording: {
@@ -113,8 +84,7 @@ function CommunityMeetingsCardGrid({ cards }) {
             MeetingDropdownOptions.unshift({
               date: (mdFile?.toc?.[0]?.value as string).split(/[0-9]{2}:[0-9]{2}/)[0],
               meeting_minutes: {
-                markDown: mdReader,
-                modalHeaderData: mdFile['contentTitle'],
+                path: getMeetingPath(mdFile?.toc?.[0]?.value as string),
                 text: 'Meeting Minutes',
               },
               meeting_recording: {
@@ -128,11 +98,6 @@ function CommunityMeetingsCardGrid({ cards }) {
     });
   };
 
-  const toggleIsModalOpen = (...modalData) => {
-    modalData && setMeetinNotesMD(modalData[0].markDown);
-    prepareModalHeader(modalData[0].modalHeaderData, modalData[1]);
-    setIsModalOpen(true);
-  };
 
   function DropDownOption(props: DropdownOptionProps) {
     const { meeting_minutes, meeting_recording, date } = props;
@@ -144,9 +109,7 @@ function CommunityMeetingsCardGrid({ cards }) {
           {meeting_recording?.text}
         </a>
         <a
-          onClick={() => {
-            toggleIsModalOpen(meeting_minutes, date);
-          }}
+          href={meeting_minutes?.path}
           className="cursor-pointer">
           {meeting_minutes?.text}
         </a>
@@ -214,23 +177,12 @@ function CommunityMeetingsCardGrid({ cards }) {
               textGradientStops="from-purple-500 to-purple-700 dark:text-purple-500"
               textGradient={false}
             />
-            <SubcardGrid key={`subcard-grid-${index}`} cards={meetingsData} toggleIsModalOpen={toggleIsModalOpen} />
+            <SubcardGrid key={`subcard-grid-${index}`} cards={meetingsData} />
             <Dropdown
               options={getDropdownOption(index == 1 ? [...cabalDropdownOptions] : [...MeetingDropdownOptions])}
               dropdownRef={meetingMinutesRef[index]}
               text="Older meeting details"
             />
-            <dialog
-              className="bg-stone-200 w-90-screen h-80-screen fixed top-20 z-50 max-h-screen w-fit border-4 border-purple-100"
-              open={isModalOpen}
-              ref={modalRef}>
-              <div className="modal-content flex flex-col">
-                {modalHeader}
-                <div className="md-wrapper overflow-y-auto scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-700  dark:text-gray-50 dark:shadow-none">
-                  {meetinNotesMD}
-                </div>
-              </div>
-            </dialog>
           </div>
         );
       })}

--- a/src/components/layout/SubcardGrid/index.tsx
+++ b/src/components/layout/SubcardGrid/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import CustomCard from '@site/src/components/ui/CustomCard';
 import { DayOfTheWeek } from '@site/src/components/utilities/DateUtils';
 
-function SubcardGrid({ cards, toggleIsModalOpen }) {
+function SubcardGrid({ cards }) {
   return (
     <div className="mb-4 flex lg:mb-6">
       {cards?.map((card, index) => {
@@ -16,9 +16,6 @@ function SubcardGrid({ cards, toggleIsModalOpen }) {
             text={card.subtitle}
             data={card.buttons}
             icon={card.icon}
-            method={meeting_minutes => {
-              toggleIsModalOpen(meeting_minutes, card.date);
-            }}
           />
         );
       })}

--- a/src/components/ui/CustomCard/index.tsx
+++ b/src/components/ui/CustomCard/index.tsx
@@ -12,7 +12,6 @@ type SubcardButtonProps = {
 type CardInfoButtonProps = {
   data: SubcardButtonProps[];
   primary: Boolean;
-  method: Function;
 };
 
 function CardHeader(props) {
@@ -43,9 +42,6 @@ function CardInfoButtons(cardInfoButtonProps: CardInfoButtonProps) {
   const {
     data = [{ text: 'button text', markDown: <>No MarkDown to Display!</> }],
     primary = false,
-    method = () => {
-      console.error('No callback method passed');
-    },
   } = cardInfoButtonProps;
   return (
     <div className="align-center mb-4 mt-8 flex flex-row flex-wrap justify-center gap-4 lg:mb-8 2xl:px-10">
@@ -57,18 +53,7 @@ function CardInfoButtons(cardInfoButtonProps: CardInfoButtonProps) {
           ))
         : data.map((button, index) => (
             <div key={index}>
-              {index == 0 ? (
-                <Button as="link" outline={true} {...button} />
-              ) : (
-                <Button
-                  as="button"
-                  method={() => {
-                    method(button);
-                  }}
-                  outline={true}
-                  {...button}
-                />
-              )}
+              <Button as="link" outline={index !== 0} {...button} />
             </div>
           ))}
     </div>


### PR DESCRIPTION
Fixes: #315
Fixes: #681

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Description
Meeting minutes on the Community page were previously displayed only in a modal, while older direct links such as
`/community/meeting/notes/2021-04-06/` returned 404.

This PR gives meeting minutes their own directly accessible pages and updates the **Meeting Minutes** links on the
Community page to point to those pages.

This restores access to existing meeting-note URLs and makes the notes bookmarkable and shareable.

#### Before screenshot / screen recording
<img width="1355" height="681" alt="Screenshot 2026-08-13 131547" src="https://github.com/user-attachments/assets/abb7339b-0d83-4cdc-ad2f-8cad2428601d" />

#### After screenshot / screen recording
<img width="1344" height="680" alt="Screenshot 2026-08-14 223346" src="https://github.com/user-attachments/assets/8c08906d-a109-4d8f-bfb8-d84b2de6a57a" />

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
