### PR TITLE
Fix #693: Add uniform bottom margin to h1 headings

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -150,7 +150,7 @@
 
   /* headings size and weight */
   h1 {
-    @apply text-4xl font-bold lg:text-5xl;
+    @apply mb-6 text-4xl font-bold lg:text-5xl;
   }
   h2 {
     @apply text-2xl font-bold lg:text-3xl;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Concisely describe the change
Fixes #693
This PR resolves an issue where `#` (`h1`) headings in Markdown files were lacking a bottom margin, causing the text directly underneath to stick too closely to the heading 

The fix adds `mb-6` to the `h1` definition in the global `@layer base` of `main.css`. This ensures that all auto-generated markdown `h1` tags get a uniform bottom margin, while safely allowing custom UI components (like `HeroHeader` and `PageHeader`) to override it with their own explicit utility classes.

#### Before screenshot / screen recording
<img width="1199" height="207" alt="Screenshot 2026-08-15 022933" src="https://github.com/user-attachments/assets/54a3da86-3ed6-4c76-9ac3-c21ea0cd0bf1" />

#### After screenshot / screen recording
<img width="1175" height="198" alt="Screenshot 2026-08-15 022939" src="https://github.com/user-attachments/assets/4eceff14-a4d8-4809-9d68-66978b93f866" />



#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
