### PR TITLE
fix(footer): center columns on small screens

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -101,6 +101,15 @@
   @apply text-blue-300 hover:text-blue-500
 }
 
+/* Below Infima's default breakpoint, footer columns stack full-width but
+   their left-aligned content leaves a large empty gap on the right.
+   Center each column so the empty space is balanced instead. */
+@media (max-width: 996px) {
+  .footer__col {
+    text-align: center;
+  }
+}
+
 .menu a {
   @apply no-underline;
 }


### PR DESCRIPTION
Fixes: #618

#### Concisely describe the change

Below 996px, the footer's Docs/Community/Projects columns stack on top of each other but stay lined up on the left. Since the link labels are short, this leaves a big empty gap on the right side of each column — that's the "excessive padding on their right" from the issue.

Added one CSS rule that centers the columns when they're stacked, so the leftover space is spread evenly instead of sitting on one side. Nothing changes above 996px, where the columns already sit side by side.

#### Before screenshot / screen recording

Narrow desktop (900px):
![before desktop](https://raw.githubusercontent.com/coderboy-yash/podman.io/assets/pr-618-screenshots/.pr-assets/618/before-desktop-narrow.png)

Mobile (390px):
![before mobile](https://raw.githubusercontent.com/coderboy-yash/podman.io/assets/pr-618-screenshots/.pr-assets/618/before-mobile.png)

#### After screenshot / screen recording

Narrow desktop (900px):
![after desktop](https://raw.githubusercontent.com/coderboy-yash/podman.io/assets/pr-618-screenshots/.pr-assets/618/after-desktop-narrow.png)

Mobile (390px):
![after mobile](https://raw.githubusercontent.com/coderboy-yash/podman.io/assets/pr-618-screenshots/.pr-assets/618/after-mobile.png)

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). The author email matches the sign-off email address.
- [x] Referenced issues using `Fixes: #618` in commit message
- [x] PR description, commit message, and GitHub comments are human-written, per LLM Policy