### PR TITLE
fix: resolve navbar logo and title collapsing on theme toggle

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -39,19 +39,40 @@
   padding: 8px 0px;
   letter-spacing: -1.5px !important;
   font-kerning: normal !important;
+  transition: color 0.4s ease;
 }
 
 #__docusaurus > nav > div.navbar__inner > div:nth-child(1) > a > b {
   font-size: xxx-large;
   line-height: 2rem;
 }
-
 .navbar__logo {
   height: 6.25rem;
+  width: 6.57rem;
+  min-width: 6.57rem;
+  min-height: 6.25rem;
+  flex: 0 0 auto;
+  transition: opacity 0.4s ease;
+}
+
+.navbar__logo img {
+  height: 100%;
+  width: 100%;
+  aspect-ratio: 266 / 253;
+  object-fit: contain;
+  display: block;
+  transition: opacity 0.4s ease, filter 0.4s ease;
+  will-change: opacity;
+}
+
+.navbar__brand {
+  min-height: 6.25rem;
+  align-items: center;
 }
 
 .navbar {
   box-shadow: none;
+  transition: background 0.4s ease, background-color 0.4s ease;
   @apply bg-gradient-to-r from-blue-500  to-purple-700 dark:from-blue-700 dark:to-purple-900;
 }
 
@@ -79,7 +100,8 @@
 
 .navbar__link,
 .navbar__brand {
-  @apply no-underline transition duration-150 ease-linear hover:text-purple-300;
+  @apply no-underline hover:text-purple-300;
+  transition: color 0.4s ease, opacity 0.4s ease;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
Fixes #702

The Podman logo image and **podman** title text in the navbar were visually collapsing into each other when toggling between light and dark modes. This happened because the `.navbar__logo` container and its `img` element had no explicit width constraints, causing a brief layout reflow during the theme switch.

## Changes

All changes are in `src/css/main.css`:

- **`.navbar__logo`** - Set explicit `width: 6.57rem`, `min-width: 6.57rem`, `min-height: 6.25rem`, and `flex: 0 0 auto` to lock its dimensions and prevent collapse during re-renders
- **`.navbar__logo img`** - Added `width: 100%`, `height: 100%`, `aspect-ratio: 266/253`, `object-fit: contain`, and `will-change: opacity` so the image always fills its container stably
- **`.navbar__brand`** - Added `min-height: 6.25rem` and `align-items: center` to prevent the brand wrapper from shrinking
- **`.navbar`** - Added smooth CSS transition (`0.4s ease`) on background properties
- **`.navbar__title`** and **`.navbar__brand`** - Added smooth color transitions (`0.4s ease`) for a polished theme switch experience

## Testing

- Tested locally by toggling dark/light mode multiple times
- Logo and title remain stable with no collapsing, jumping, or flickering
- Transitions are smooth across theme switches