### PR TITLE
Fix #164: Mention user local configuration files in installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -599,6 +599,7 @@ NOTE: On macOS or Windows, please run the command `podman machine ssh` to enter 
 
 ```
 $ cat /etc/containers/registries.conf
+# Or $HOME/.config/containers/registries.conf for rootless Podman
 # For more information on this configuration file, see containers-registries.conf(5).
 #
 # NOTE: RISK OF USING UNQUALIFIED IMAGE NAMES
@@ -693,6 +694,7 @@ Note this is not a volume mount. The content of the volumes is copied into conta
 
 ```
 cat /usr/share/containers/mounts.conf
+# Or $HOME/.config/containers/mounts.conf for rootless Podman
 /usr/share/rhel/secrets:/run/secrets
 ```
 
@@ -715,6 +717,7 @@ The link above takes you to the seccomp.json
 
 ```
 cat /etc/containers/policy.json
+# Or $HOME/.config/containers/policy.json for rootless Podman
 {
     "default": [
         {


### PR DESCRIPTION
What this does: This PR updates the Installation documentation to explicitly mention user-local configuration paths (like ~/.config/containers/registries.conf).

Why we need it: The docs previously only highlighted the system-wide configuration paths (like /etc/containers/registries.conf). This was leaving rootless Podman users in the dark about where to place their personal configuration files.