### PR TITLE
fix: current time widget shows build time instead of visitor's time

### DIFF
--- a/src/components/content/DateTimeBox/index.tsx
+++ b/src/components/content/DateTimeBox/index.tsx
@@ -1,40 +1,53 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+function formatTime(timeZone: string): [string, string] {
+  const now = new Date();
+  return [
+    now.toLocaleString('en-US', {
+      timeZone,
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    }),
+    Intl.DateTimeFormat('en-US', { timeZone, timeZoneName: 'long' }).format(now).split(',')[1],
+  ];
+}
+
+function Clock(): JSX.Element {
+  const [centralEuropeTime, setCentralEuropeTime] = useState(() => formatTime('Europe/Paris'));
+  const [easternTime, setEasternTime] = useState(() => formatTime('America/New_York'));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCentralEuropeTime(formatTime('Europe/Paris'));
+      setEasternTime(formatTime('America/New_York'));
+    }, 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <>
+      <div className="text-center">
+        <h4 className="mb-2 text-3xl font-extrabold text-purple-500 dark:text-gray-100">{centralEuropeTime[0]}</h4>
+        <p className="w-40 font-bold text-blue-900">{centralEuropeTime[1]}</p>
+      </div>
+      <div className="text-center">
+        <h4 className="mb-2 text-3xl font-extrabold text-purple-500 dark:text-gray-100">{easternTime[0]}</h4>
+        <p className="w-40 font-bold text-blue-900">{easternTime[1]}</p>
+      </div>
+    </>
+  );
+}
 
 function DateTimeBox(): JSX.Element {
-  const date = new Date();
-  const centralEuropeTime = [
-    date.toLocaleString('en-US', {
-      timeZone: 'Europe/Paris',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: false,
-    }),
-    Intl.DateTimeFormat('en-US', { timeZone: 'Europe/Paris', timeZoneName: 'long' }).format().split(',')[1],
-  ];
-  const easternTime = [
-    date.toLocaleString('en-US', {
-      timeZone: 'America/New_York',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: false,
-    }),
-    Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', timeZoneName: 'long' }).format().split(',')[1],
-  ];
-
   return (
     <article className="mb-10 max-w-lg rounded-lg bg-aqua shadow-md dark:bg-purple-900">
       <div className="m-4 grid grid-cols-2 gap-x-4 lg:m-8">
         <div className="col-span-full mb-5 text-center">
           <h3 className="font-bold text-gray-300 dark:text-gray-100">Current Time</h3>
         </div>
-        <div className="text-center">
-          <h4 className="mb-2 text-3xl font-extrabold text-purple-500 dark:text-gray-100">{centralEuropeTime[0]}</h4>
-          <p className="w-40 font-bold text-blue-900">{centralEuropeTime[1]}</p>
-        </div>
-        <div className="text-center">
-          <h4 className="mb-2 text-3xl font-extrabold text-purple-500 dark:text-gray-100">{easternTime[0]}</h4>
-          <p className="w-40 font-bold text-blue-900">{easternTime[1]}</p>
-        </div>
+        <BrowserOnly>{() => <Clock />}</BrowserOnly>
       </div>
     </article>
   );


### PR DESCRIPTION

Fixes #712 

The "Current Time" box on the community page showed the time the site was built, not the visitor's actual time, because `new Date()` ran once on the build server. This PR wraps the clock formatting in a stateful `Clock` component and renders it client-side with `<BrowserOnly>`, updating the time in real-time.

#### Before screenshot 

**Live Production Site (time stays frozen at 06:40):**

*First check:*
<img width="1782" height="671" alt="Screenshot 2026-08-18 101105" src="https://github.com/user-attachments/assets/5d86513a-d4eb-4faa-89cc-4a8d6b42003d" />


*Several minutes later (still shows 06:40):*
<img width="1807" height="589" alt="Screenshot 2026-08-18 101207" src="https://github.com/user-attachments/assets/15b33010-fe01-46a9-9b35-754790124d2d" />


#### After screenshot 

**Local Site (time updates dynamically):**

*Initial load (shows 06:40):*
<img width="1720" height="672" alt="Screenshot 2026-08-18 101147" src="https://github.com/user-attachments/assets/60408a89-fbee-4890-9e1f-987d1684ccd9" />


*One minute later (advances to 06:41):*
<img width="1757" height="710" alt="Screenshot 2026-08-18 101157" src="https://github.com/user-attachments/assets/2825f237-a2fb-4b72-93ee-a5cc9d3b57d0" />


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
