### PR TITLE
Fix #48: Add Podman Desktop steps to Get Started

### DIFF
--- a/src/components/layout/PageHeader/index.tsx
+++ b/src/components/layout/PageHeader/index.tsx
@@ -61,19 +61,22 @@ function PageHeaderSupplementalInfo({ image, basicResources }: PageHeaderSupplem
 
 function Instructions({ instructions }: InstructionsProps) {
   if (instructions) {
+    const buttons = instructions.buttons || (instructions.button ? [instructions.button] : []);
     return (
       <div>
         <h3 className="text-gray-700 mb-4">{instructions.title}</h3>
         <p>{instructions.subtitle}</p>
          <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:gap-4 xl:flex-col">
-              <li>
+            {buttons.map((btn: any, index: number) => (
+              <li key={index}>
                 <a
-                  href={instructions.button.path}
+                  href={btn.path}
                   className="no-underline hover:no-underline flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
-                  <span>{instructions.button.text}</span>
-                  <Icon icon={instructions.button.icon} className="order-first hidden lg:block" />
+                  <span>{btn.text}</span>
+                  <Icon icon={btn.icon} className="order-first hidden lg:block" />
                 </a>
               </li>
+            ))}
         </ul>
       </div>
     )

--- a/static/data/get-started.ts
+++ b/static/data/get-started.ts
@@ -5,11 +5,18 @@ const header = {
   instructions: {
     title: 'First Things First: Installing Podman',
     subtitle: 'For installing or building Podman, please see the installation instructions:',
-    button: {
-      text: 'Installation Instructions',
-      path: 'docs/installation',
-      icon: 'fa6-solid:book',
-    },
+    buttons: [
+      {
+        text: 'Installation Instructions',
+        path: 'docs/installation',
+        icon: 'fa6-solid:book',
+      },
+      {
+        text: 'Podman Desktop',
+        path: 'https://podman-desktop.io/downloads',
+        icon: 'fa6-solid:desktop',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
- Fix #122: Make Testimonial Avatars Clickable
- Fix #164: Document User-Local Config Files for Rootless Podman
- Fix #48: Add Podman Desktop to the Get Started Page

