### PR TITLE
Update community.ts

### DIFF
--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -191,7 +191,7 @@ const submittingIssues = [
     ],
     checkList: [
       'Well-documented code changes.',
-      'Additional testcases. Ideally m they should fail w/o your code change applied.',
+      'Additional testcases. Ideally, they should fail w/o your code change applied.',
       'Documentation changes.',
     ],
     button: {


### PR DESCRIPTION
Fixes: #717 
Solved the very small typo error 
 "Ideally m they should fail" → should be "Ideally, they should fail"
<img width="1903" height="833" alt="Screenshot 2026-08-18 190134" src="https://github.com/user-attachments/assets/ecd702aa-db9d-465f-9cab-f13066275f00" />
<img width="641" height="328" alt="Screenshot 2026-08-18 190145" src="https://github.com/user-attachments/assets/afc58386-0b48-470e-9baa-abb5134e551d" />