### PR TITLE
Fix broken Twitter avatar image for Gerald Venzl on homepage testimon…

### DIFF
--- a/static/data/testimonials.ts
+++ b/static/data/testimonials.ts
@@ -39,7 +39,7 @@ export const testimonials = [
     social: 'twitter',
     path: 'https://twitter.com/GeraldVenzl/status/1656361050135212032',
     date: 'May 10, 2023',
-    avatar: 'https://pbs.twimg.com/profile_images/1057877042438397952/DVNj9EiF_400x400.jpg',
+    avatar: 'https://github.com/gvenzl.png',
     featuredlink: 'https://blogs.oracle.com/scoter/post/run-oracle-database-23c-with-podman-desktop',
   },
 ];


### PR DESCRIPTION
Fixes: #720 
Gerald Venzl's profile image on the homepage testimonials was broken because his old Twitter/X image URL expired and returned a 404 error.

Solution: Replaced the broken, hardcoded Twitter image link with his dynamic GitHub proxy avatar, which reliably auto-updates and prevents future broken links.

Before:
<img width="1916" height="868" alt="Screenshot 2026-08-19 093645" src="https://github.com/user-attachments/assets/588a7730-b58b-4fc2-a566-e7170d601a81" />


After : 
<img width="1898" height="858" alt="Screenshot 2026-08-19 100208" src="https://github.com/user-attachments/assets/c31763d8-9931-4dc6-93de-bafbf5fe9bd3" />
