### PR TITLE
fix (#119) : remove duplicate 'Getting Started with Podman' heading

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,6 @@ title: Getting Started with Podman
 
 ![Podman logo](/logos/optimized/podman-logo-orig-884w-293h.webp#gh-light-mode-only)![Podman logo](/logos/optimized/podman-logo-dark-884w-293h.webp#gh-dark-mode-only)
 
-# Getting Started with Podman
-
 Podman is a utility provided as part of the libpod library. It can be used to
 create and maintain containers. The following tutorial will teach you how to set
 up Podman and perform some basic commands.


### PR DESCRIPTION
The page title was appearing twice - once from the frontmatter title and once from the H1 heading in the markdown content. Docusaurus automatically uses the frontmatter title as the page heading, so the duplicate H1 is unnecessary and causes visual duplication in the docs.

Fixes #119

<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Concisely describe the change

#### Before screenshot / screen recording
<img width="1470" height="805" alt="image" src="https://github.com/user-attachments/assets/4878c14f-ecd2-4e1e-809b-e9671f82c5e4" />


#### After screenshot / screen recording
<img width="1470" height="803" alt="image" src="https://github.com/user-attachments/assets/08a293bc-2a5b-4d02-8284-c397ac5531a3" />


#### Checklist




- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
